### PR TITLE
e2e: harness autoplayer com evidência visual + dados de balanceamento por PR

### DIFF
--- a/.github/workflows/e2e-evidence.yml
+++ b/.github/workflows/e2e-evidence.yml
@@ -1,0 +1,84 @@
+name: e2e — evidência visual + dados de balanceamento
+
+# Joga o jogo com um bot autoplayer em rounds determinísticos e gera, a cada PR:
+#   - screenshots (começo/meio/fim + resultado)  -> artifact
+#   - gráfico de score no tempo + metrics.json   -> artifact
+#   - tabela-resumo de balanceamento             -> comentário no PR
+
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - "tests/e2e/**"
+      - "package.json"
+      - ".github/workflows/e2e-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  play:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm install
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Play rounds (Fácil + Insano)
+        run: |
+          node tests/e2e/run.mjs --players 1 --seeds 1,2,3,4,5 --out tests/e2e/out/facil
+          node tests/e2e/run.mjs --players 4 --seeds 1,2,3,4,5 --out tests/e2e/out/insano
+
+      - name: Upload evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: overgarden-e2e
+          path: tests/e2e/out
+          if-no-files-found: error
+
+      - name: Comment balancing summary on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const read = (p) => fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
+            const facil = read('tests/e2e/out/facil/summary.md');
+            const insano = read('tests/e2e/out/insano/summary.md');
+            const marker = '<!-- overgarden-e2e -->';
+            const body = [
+              marker,
+              facil,
+              '',
+              '<details><summary>Insano (5 seeds)</summary>',
+              '',
+              insano,
+              '',
+              '</details>',
+              '',
+              `_Atualizado pelo run [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Screenshots e \`metrics.json\` no artifact **overgarden-e2e**._`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+tests/e2e/out/

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,7 @@ sozinho ou em co-op, com caos crescente.
 - [ ] Níveis **data-driven** (JSON: estações, canteiros, pedidos, meta, tempo).
 - [ ] **Colisão real** com estações/obstáculos.
 - [ ] Tick determinístico + separação de sistemas (prep p/ co-op/replay).
-- [ ] **CI no PR**: lint + testes de lógica headless (já há harness Playwright).
+- [x] **CI no PR**: harness e2e (bot autoplayer headless) que gera evidência visual + dados de balanceamento por seed (`tests/e2e/`).
 - [ ] Pipeline de assets (poço/água animados, decorações, tilemap da cena Unity).
 
 **Marketing**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "overgarden-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "overgarden-web",
+      "version": "0.1.0",
+      "devDependencies": {
+        "playwright": "^1.49.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "overgarden-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Overgarden HTML5 web port + e2e balancing harness.",
+  "type": "module",
+  "scripts": {
+    "e2e": "node tests/e2e/run.mjs",
+    "e2e:easy": "node tests/e2e/run.mjs --players 1",
+    "e2e:insane": "node tests/e2e/run.mjs --players 4"
+  },
+  "devDependencies": {
+    "playwright": "^1.49.0"
+  }
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,46 @@
+# Overgarden — e2e balancing harness
+
+An autoplayer bot plays full headless rounds of the web build and produces
+**visual evidence** + **balancing data** on every PR.
+
+## What it does
+
+1. Serves `web/` and opens it in headless Chromium with `?debug&seed=N`.
+2. Injects a heuristic **bot** (`bot.js`) that plays the loop (prepare → plant →
+   water → harvest → deliver) through the real input path, at real game speed.
+3. A deterministic, seeded `tick(dt)` advances a 150s round in a fraction of a
+   second; the **harness** (`harness.js`) records per-tick metrics.
+4. `run.mjs` runs several seeds and writes to `tests/e2e/out/`:
+   - `screenshots/*.png` — start / mid / late / result (visual evidence)
+   - `score-over-time.svg` — score curves vs. star thresholds
+   - `metrics.json` — every run + aggregate + the tuning snapshot evaluated
+   - `report.md` — full human report
+   - `summary.md` — short table posted as a PR comment
+
+## Run locally
+
+```bash
+npm install
+npx playwright install --with-deps chromium
+npm run e2e                       # default: Fácil, seeds 1..5
+node tests/e2e/run.mjs --players 4 --seeds 1,2,3   # Insano
+open tests/e2e/out/report.md
+```
+
+## Using it to rebalance
+
+Tweak the `TUNE` / `ROUND` / `ORDER` tables in `web/game.js`, re-run, and
+compare aggregates. Rules of thumb (also printed in `report.md`):
+
+- **Always 0★** → too hard (or `ROUND.stars` thresholds too high). **Always 3★** → too easy.
+- **High deaths / low waters** → `TUNE.lifeBase` / `wiltGrace` too tight, or player too slow to cover the map.
+- **High expired orders** → `ORDER.timeBase` / `diffTime` too short, or spawns too fast.
+- **High idle %** → bot ran out of work: there's slack, the tuning can be tightened.
+
+The bot is intentionally **consistent, not optimal** — so score deltas between
+runs are attributable to tuning changes, not bot variance.
+
+## Reproducibility
+
+Only gameplay-affecting randomness (the order stream) is seeded via a mulberry32
+PRNG (`?seed=`). With a fixed seed + fixed timestep, runs are deterministic.

--- a/tests/e2e/bot.js
+++ b/tests/e2e/bot.js
@@ -1,0 +1,151 @@
+"use strict";
+/*
+ * Overgarden autoplayer — a heuristic bot that "plays" a headless round so the
+ * e2e harness can produce comparable balancing data and visual evidence.
+ *
+ * It drives the game through the SAME input path a human uses: it sets the
+ * exposed `keys` / `justPressed` maps each frame, then the harness advances one
+ * deterministic tick. Movement therefore happens at real game speed, so the
+ * data reflects whether a competent player can physically keep up with the
+ * current tuning — which is exactly what we want to rebalance against.
+ *
+ * The policy is intentionally simple and stable (not optimal): consistency
+ * matters more than skill so that score deltas between tuning changes are
+ * attributable to the tuning, not to bot variance.
+ *
+ * Injected into the page by run.mjs; attaches window.__OG_BOT__.
+ */
+(function () {
+  const MOVE_KEYS = ["w", "a", "s", "d", "shift", "e", "q"];
+
+  const bot = {
+    wantSeedIndex: 0,
+
+    // Reset every frame; held movement keys must be re-asserted each tick
+    // because tick() only clears the one-shot justPressed map.
+    _clear(OG) {
+      for (const k of MOVE_KEYS) OG.keys[k] = false;
+    },
+    _press(OG, k) {
+      OG.keys[k] = true;
+      OG.justPressed[k] = true;
+    },
+    _moveToward(OG, p, tx, ty, run) {
+      if (ty - p.y < -6) OG.keys.w = true;
+      else if (ty - p.y > 6) OG.keys.s = true;
+      if (tx - p.x < -6) OG.keys.a = true;
+      else if (tx - p.x > 6) OG.keys.d = true;
+      if (run && p.stamina > 25) OG.keys.shift = true;
+    },
+
+    decide(OG) {
+      const g = OG.game;
+      if (!g || OG.gameState !== "playing" || g.paused) return;
+      this._clear(OG);
+      const P = g.player;
+      const H = OG.HOLD, S = OG.STAGE;
+
+      // --- Seed menu: navigate to the wanted plant, then select it. ---
+      if (g.seedMenu.open) {
+        if (g.seedMenu.index < this.wantSeedIndex) this._press(OG, "d");
+        else if (g.seedMenu.index > this.wantSeedIndex) this._press(OG, "a");
+        else this._press(OG, "e");
+        return;
+      }
+
+      const station = (type) => g.stations.find((s) => s.type === type);
+      const d2 = (x, y) => Math.hypot(P.x - x, P.y - y);
+      const growing = (pl) => pl.stage >= S.SMALL && pl.stage < S.READY;
+      const reach = OG.TUNE.interactRadius * 0.7;
+
+      // Pick the nearest plot matching a predicate.
+      const pickPlot = (pred) => {
+        let best = null, bd = Infinity;
+        for (const pl of g.plots) {
+          if (!pred(pl)) continue;
+          const d = d2(pl.x, pl.y);
+          if (d < bd) { bd = d; best = pl; }
+        }
+        return best;
+      };
+
+      const orderNeed = (name) =>
+        g.orders.filter((o) => o.plant.name === name && o.need > 0)
+          .reduce((a, o) => a + o.need, 0);
+
+      // Go to a fixed point; interact (press e) once within reach. Far => run.
+      const goTo = (x, y, prep) => {
+        if (d2(x, y) > reach) { this._moveToward(OG, P, x, y, d2(x, y) > 200); }
+        else { if (prep) prep(); this._press(OG, "e"); }
+      };
+      const goToPlot = (pl, prep) => goTo(pl.x, pl.y, prep);
+
+      // --- Act on what we're already holding (finish the sub-goal). ---
+      if (P.holding === H.PLANT) { goTo(station("sales").x, station("sales").y); return; }
+      if (P.holding === H.TOOL) {
+        // Reclaim dead plots first — they block capacity until cleared.
+        const pl = pickPlot((x) => x.stage === S.DIED) || pickPlot((x) => x.stage === S.VIRGIN);
+        if (pl) goToPlot(pl); else this._press(OG, "q");
+        return;
+      }
+      if (P.holding === H.WATER) {
+        const pl = pickPlot((x) => growing(x) && (x.wilt > 0 || x.life < 0.6));
+        if (pl) goToPlot(pl); else this._press(OG, "q");
+        return;
+      }
+      if (P.holding === H.SEED) {
+        const pl = pickPlot((x) => x.stage === S.TREATED);
+        if (pl) goToPlot(pl); else this._press(OG, "q");
+        return;
+      }
+
+      // --- Hands empty: choose the highest-value thing to start. ---
+      // Cap concurrent crops to what one runner can keep watered, so the bot
+      // doesn't over-plant and let everything wilt — a skilled player paces.
+      const GROW_CAP = 1;
+      const growingCount = g.plots.filter(growing).length;
+
+      // 1) Rescue a wilting plant (reversible, but about to die) — top priority.
+      const wilting = pickPlot((x) => growing(x) && x.wilt > 0);
+      if (wilting) { goTo(station("water").x, station("water").y); return; }
+
+      // 2) Harvest a ready plant that an order wants (turns into a delivery).
+      const ready = pickPlot((x) => x.stage === S.READY && orderNeed(x.plant.name) > 0);
+      if (ready) { goToPlot(ready); return; }
+
+      // 3) Preventive watering of the thirstiest crop before it wilts.
+      const thirsty = pickPlot((x) => growing(x) && x.life < 0.5);
+      if (thirsty) { goTo(station("water").x, station("water").y); return; }
+
+      // 4) Clear a dead plot to free capacity (needs the tool).
+      const dead = pickPlot((x) => x.stage === S.DIED);
+      if (dead) { goTo(station("tool").x, station("tool").y); return; }
+
+      // 5) Build supply for the most urgent order lacking grown stock — but only
+      //    up to the cap, so we can sustain watering.
+      const supply = (name) =>
+        g.plots.filter((x) => (growing(x) || x.stage === S.READY) && x.plant && x.plant.name === name).length;
+      const unmet = g.orders
+        .filter((o) => o.need > supply(o.plant.name))
+        .sort((a, b) => a.timeLeft - b.timeLeft)[0];
+      const treated = pickPlot((x) => x.stage === S.TREATED);
+      const virgin = pickPlot((x) => x.stage === S.VIRGIN);
+
+      if (growingCount < GROW_CAP && unmet) {
+        if (treated) {
+          this.wantSeedIndex = OG.PLANTS.findIndex((p) => p.name === unmet.plant.name);
+          goTo(station("seed").x, station("seed").y);
+          return;
+        }
+        if (virgin) { goTo(station("tool").x, station("tool").y); return; }
+      }
+
+      // 6) Idle: prime one treated plot so planting is instant when an order lands.
+      if (growingCount < GROW_CAP && !treated && virgin) {
+        goTo(station("tool").x, station("tool").y);
+      }
+    },
+  };
+
+  window.__OG_BOT__ = bot;
+})();

--- a/tests/e2e/harness.js
+++ b/tests/e2e/harness.js
@@ -1,0 +1,129 @@
+"use strict";
+/*
+ * In-page harness: starts a headless round, drives the bot, and accumulates
+ * balancing metrics by diffing game state every tick. Runs inside the browser
+ * so a full 150s round costs a handful of cross-process calls, not thousands.
+ *
+ * Injected by run.mjs; attaches window.__OG_HARNESS__.
+ */
+(function () {
+  const DT = 1 / 30; // fixed timestep — deterministic round length
+  let M = null;      // metrics accumulator
+  let prev = null;   // previous-tick snapshot for event detection
+
+  function snap(OG) {
+    const g = OG.game, S = OG.STAGE;
+    return {
+      score: g.score,
+      delivered: g.stats.delivered,
+      expired: g.stats.expired,
+      px: g.player.x, py: g.player.y,
+      plots: g.plots.map((p) => ({ stage: p.stage, life: p.life })),
+      growing: (st) => st >= S.SMALL && st < S.READY,
+    };
+  }
+
+  function init(OG) {
+    const g = OG.game;
+    M = {
+      ticks: 0,
+      deaths: 0, waters: 0, harvests: 0, treats: 0, plants: 0,
+      distance: 0, idleTicks: 0,
+      hold: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0 }, // ticks per HOLD state
+      maxCombo: 0,
+      activeOrdersSum: 0,
+      series: [],
+    };
+    prev = snap(OG);
+    sample(OG, true); // t=0 baseline
+  }
+
+  function sample(OG, force) {
+    const g = OG.game, S = OG.STAGE;
+    const elapsed = OG.ROUND.duration - g.time;
+    const last = M.series[M.series.length - 1];
+    if (!force && last && elapsed - last.t < 1) return; // ~1s cadence
+    const grow = g.plots.filter((p) => p.stage >= S.SMALL && p.stage < S.READY);
+    const avgLife = grow.length ? grow.reduce((a, p) => a + p.life, 0) / grow.length : 1;
+    M.series.push({
+      t: +elapsed.toFixed(1),
+      score: g.score,
+      orders: g.orders.length,
+      combo: g.combo,
+      growing: grow.length,
+      ready: g.plots.filter((p) => p.stage === S.READY).length,
+      dead: g.plots.filter((p) => p.stage === S.DIED).length,
+      avgLife: +avgLife.toFixed(3),
+      stamina: Math.round(g.player.stamina),
+    });
+  }
+
+  function observe(OG) {
+    const g = OG.game, S = OG.STAGE;
+    const cur = snap(OG);
+    M.ticks++;
+    M.distance += Math.hypot(cur.px - prev.px, cur.py - prev.py);
+    if (!g.player.moving) M.idleTicks++;
+    M.hold[g.player.holding] = (M.hold[g.player.holding] || 0) + 1;
+    if (g.combo > M.maxCombo) M.maxCombo = g.combo;
+    M.activeOrdersSum += g.orders.length;
+
+    for (let i = 0; i < cur.plots.length; i++) {
+      const a = prev.plots[i], b = cur.plots[i];
+      if (a.stage !== S.DIED && b.stage === S.DIED) M.deaths++;
+      if (a.stage === S.VIRGIN && b.stage === S.TREATED) M.treats++;
+      if (a.stage === S.TREATED && b.stage === S.SMALL) M.plants++;
+      if (a.stage === S.READY && b.stage === S.VIRGIN) M.harvests++;
+      const grow = b.stage >= S.SMALL && b.stage < S.READY;
+      if (grow && b.life - a.life > 0.3) M.waters++; // life reset by watering
+    }
+    prev = cur;
+  }
+
+  window.__OG_HARNESS__ = {
+    start({ players = 1, seed = null } = {}) {
+      window.__OG__.startHeadless({ players, seed });
+      init(window.__OG__);
+      return true;
+    },
+    // Advance ticks until game.time <= untilTime (or the round ends).
+    run({ untilTime = 0, render = false } = {}) {
+      const OG = window.__OG__, BOT = window.__OG_BOT__;
+      let guard = 20000;
+      while (OG.gameState === "playing" && OG.game.time > untilTime && guard-- > 0) {
+        BOT.decide(OG);
+        OG.tick(DT, render);
+        if (OG.gameState === "playing") { observe(OG); sample(OG, false); }
+      }
+      return { state: OG.gameState, time: OG.game ? OG.game.time : 0 };
+    },
+    metrics() {
+      const OG = window.__OG__, g = OG.game, R = OG.ROUND;
+      const s = g.score;
+      const stars = s >= R.stars[2] ? 3 : s >= R.stars[1] ? 2 : s >= R.stars[0] ? 1 : 0;
+      const t = Math.max(1, M.ticks);
+      return {
+        summary: {
+          score: s, stars,
+          delivered: g.stats.delivered,
+          expired: g.stats.expired,
+          ordersSpawned: g.orderId - 1,
+          deaths: M.deaths, waters: M.waters, harvests: M.harvests,
+          treats: M.treats, plants: M.plants,
+          maxCombo: M.maxCombo,
+          idlePct: +(100 * M.idleTicks / t).toFixed(1),
+          distance: Math.round(M.distance),
+          avgActiveOrders: +(M.activeOrdersSum / t).toFixed(2),
+          holdPct: {
+            nothing: +(100 * M.hold[0] / t).toFixed(1),
+            seed: +(100 * M.hold[1] / t).toFixed(1),
+            water: +(100 * M.hold[2] / t).toFixed(1),
+            tool: +(100 * M.hold[3] / t).toFixed(1),
+            plant: +(100 * M.hold[4] / t).toFixed(1),
+          },
+        },
+        series: M.series,
+      };
+    },
+  };
+})();

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -1,0 +1,254 @@
+// Overgarden e2e balancing harness.
+//
+// Launches the web build in headless Chromium, lets the autoplayer bot play
+// full rounds across several deterministic seeds, then emits:
+//   - out/screenshots/*.png  — visual evidence (start / mid / late / result)
+//   - out/score-over-time.svg — score curves vs star thresholds
+//   - out/metrics.json        — full per-run metrics + aggregate + tuning snapshot
+//   - out/report.md           — human report embedding the above
+//   - out/summary.md          — short table for the PR comment
+//
+// Usage: node tests/e2e/run.mjs [--players N] [--seeds 1,2,3] [--out DIR]
+import { chromium } from "playwright";
+import http from "node:http";
+import { readFile, mkdir, writeFile, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = path.resolve(HERE, "../../web");
+
+// ---- args -----------------------------------------------------------------
+const argv = process.argv.slice(2);
+const getArg = (name, def) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+};
+const PLAYERS = parseInt(getArg("--players", "1"), 10);
+const SEEDS = getArg("--seeds", "1,2,3,4,5").split(",").map((s) => parseInt(s, 10));
+const OUT = path.resolve(process.cwd(), getArg("--out", "tests/e2e/out"));
+const EVIDENCE_SEED = SEEDS[0];
+
+// ---- tiny static server ----------------------------------------------------
+const MIME = {
+  ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+  ".json": "application/json", ".png": "image/png", ".wav": "audio/wav",
+  ".mp3": "audio/mpeg", ".svg": "image/svg+xml",
+};
+function startServer() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = decodeURIComponent(req.url.split("?")[0]);
+      const rel = url === "/" ? "/index.html" : url;
+      const file = path.join(WEB_DIR, path.normalize(rel));
+      if (!file.startsWith(WEB_DIR)) { res.writeHead(403).end(); return; }
+      const body = await readFile(file);
+      res.writeHead(200, { "Content-Type": MIME[path.extname(file)] || "application/octet-stream" });
+      res.end(body);
+    } catch {
+      res.writeHead(404).end("not found");
+    }
+  });
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+
+// ---- one round -------------------------------------------------------------
+async function playRound(browser, base, seed, withEvidence) {
+  const page = await browser.newPage({ viewport: { width: 980, height: 700 } });
+  await page.goto(`${base}/index.html?debug&seed=${seed}`);
+  await page.waitForFunction(() => window.__OG__ && window.__OG__.assetsReady(), null, { timeout: 30000 });
+  await page.addScriptTag({ path: path.join(HERE, "bot.js") });
+  await page.addScriptTag({ path: path.join(HERE, "harness.js") });
+  await page.evaluate(({ players, seed }) => window.__OG_HARNESS__.start({ players, seed }), { players: PLAYERS, seed });
+
+  const shots = [];
+  if (withEvidence) {
+    const dir = path.join(OUT, "screenshots");
+    const duration = await page.evaluate(() => window.__OG__.ROUND.duration);
+    const checkpoints = [
+      { label: "01_start", at: 5 },
+      { label: "02_mid", at: Math.round(duration * 0.5) },
+      { label: "03_late", at: Math.round(duration * 0.92) },
+    ];
+    for (const cp of checkpoints) {
+      await page.evaluate((untilTime) => window.__OG_HARNESS__.run({ untilTime, render: true }), duration - cp.at);
+      const file = path.join(dir, `${cp.label}.png`);
+      await page.locator("#game").screenshot({ path: file });
+      shots.push(file);
+    }
+    await page.evaluate(() => window.__OG_HARNESS__.run({ untilTime: 0, render: true }));
+    const resultFile = path.join(dir, "04_result.png");
+    await page.locator("#game-wrapper").screenshot({ path: resultFile });
+    shots.push(resultFile);
+  } else {
+    await page.evaluate(() => window.__OG_HARNESS__.run({ untilTime: 0, render: false }));
+  }
+
+  const metrics = await page.evaluate(() => window.__OG_HARNESS__.metrics());
+  const tuning = await page.evaluate(() => ({ TUNE: window.__OG__.TUNE, ROUND: window.__OG__.ROUND, ORDER: window.__OG__.ORDER }));
+  await page.close();
+  return { seed, ...metrics, tuning, shots: shots.map((f) => path.relative(OUT, f)) };
+}
+
+// ---- aggregate helpers -----------------------------------------------------
+const mean = (a) => a.reduce((x, y) => x + y, 0) / a.length;
+const median = (a) => { const s = [...a].sort((x, y) => x - y); const m = s.length >> 1; return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2; };
+
+function aggregate(runs) {
+  const score = runs.map((r) => r.summary.score);
+  const starDist = [0, 0, 0, 0];
+  for (const r of runs) starDist[r.summary.stars]++;
+  const avg = (key) => +mean(runs.map((r) => r.summary[key])).toFixed(2);
+  return {
+    runs: runs.length,
+    score: { mean: Math.round(mean(score)), median: Math.round(median(score)), min: Math.min(...score), max: Math.max(...score) },
+    starDistribution: { "0": starDist[0], "1": starDist[1], "2": starDist[2], "3": starDist[3] },
+    avgStars: +mean(runs.map((r) => r.summary.stars)).toFixed(2),
+    delivered: avg("delivered"), expired: avg("expired"), ordersSpawned: avg("ordersSpawned"),
+    deaths: avg("deaths"), waters: avg("waters"), harvests: avg("harvests"),
+    maxCombo: Math.max(...runs.map((r) => r.summary.maxCombo)),
+    idlePct: avg("idlePct"), avgActiveOrders: avg("avgActiveOrders"),
+  };
+}
+
+// ---- SVG score-over-time chart --------------------------------------------
+function buildChart(runs, tuning) {
+  const W = 760, H = 360, pad = { l: 56, r: 16, t: 16, b: 36 };
+  const iw = W - pad.l - pad.r, ih = H - pad.t - pad.b;
+  const duration = tuning.ROUND.duration;
+  const maxScore = Math.max(tuning.ROUND.stars[2] * 1.1, ...runs.flatMap((r) => r.series.map((s) => s.score)));
+  const x = (t) => pad.l + (t / duration) * iw;
+  const y = (s) => pad.t + ih - (s / maxScore) * ih;
+  const colors = ["#2e8b57", "#c0392b", "#2980b9", "#8e44ad", "#d68910", "#16a085"];
+
+  const parts = [];
+  parts.push(`<rect x="0" y="0" width="${W}" height="${H}" fill="#fbfdf7" stroke="#dfe6da"/>`);
+  // star threshold lines
+  tuning.ROUND.stars.forEach((s, i) => {
+    const yy = y(s).toFixed(1);
+    parts.push(`<line x1="${pad.l}" y1="${yy}" x2="${W - pad.r}" y2="${yy}" stroke="#e0b341" stroke-dasharray="4 4"/>`);
+    parts.push(`<text x="${W - pad.r - 2}" y="${(y(s) - 4).toFixed(1)}" font-size="11" fill="#b8860b" text-anchor="end">${"★".repeat(i + 1)} ${s}</text>`);
+  });
+  // axes
+  parts.push(`<line x1="${pad.l}" y1="${pad.t}" x2="${pad.l}" y2="${pad.t + ih}" stroke="#9aa39a"/>`);
+  parts.push(`<line x1="${pad.l}" y1="${pad.t + ih}" x2="${W - pad.r}" y2="${pad.t + ih}" stroke="#9aa39a"/>`);
+  for (let t = 0; t <= duration; t += 30) {
+    parts.push(`<text x="${x(t).toFixed(1)}" y="${H - 12}" font-size="11" fill="#5a635a" text-anchor="middle">${t}s</text>`);
+  }
+  parts.push(`<text x="14" y="${(pad.t + ih / 2).toFixed(1)}" font-size="11" fill="#5a635a" transform="rotate(-90 14 ${(pad.t + ih / 2).toFixed(1)})" text-anchor="middle">score</text>`);
+  // score lines
+  runs.forEach((r, i) => {
+    const pts = r.series.map((s) => `${x(s.t).toFixed(1)},${y(s.score).toFixed(1)}`).join(" ");
+    parts.push(`<polyline points="${pts}" fill="none" stroke="${colors[i % colors.length]}" stroke-width="2" opacity="0.85"/>`);
+    parts.push(`<text x="${W - pad.r - 4}" y="${(pad.t + 14 + i * 14).toFixed(1)}" font-size="11" fill="${colors[i % colors.length]}" text-anchor="end">seed ${r.seed}: ${r.summary.score} (${"★".repeat(r.summary.stars) || "—"})</text>`);
+  });
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">${parts.join("")}</svg>`;
+}
+
+// ---- report ----------------------------------------------------------------
+const DIFF_LABEL = { 1: "Fácil", 2: "Médio", 3: "Difícil", 4: "Insano" };
+
+function summaryTable(agg) {
+  return [
+    `| métrica | valor |`,
+    `| --- | --- |`,
+    `| Runs (seeds) | ${agg.runs} |`,
+    `| Score médio / mediano | **${agg.score.mean}** / ${agg.score.median} |`,
+    `| Score min–max | ${agg.score.min} – ${agg.score.max} |`,
+    `| Estrelas (média) | ${"★".repeat(Math.round(agg.avgStars)) || "—"} (${agg.avgStars}) |`,
+    `| Distribuição ★ (0/1/2/3) | ${agg.starDistribution["0"]}/${agg.starDistribution["1"]}/${agg.starDistribution["2"]}/${agg.starDistribution["3"]} |`,
+    `| Pedidos entregues / perdidos | ${agg.delivered} / ${agg.expired} |`,
+    `| Pedidos gerados (média) | ${agg.ordersSpawned} |`,
+    `| Plantas mortas (média) | ${agg.deaths} |`,
+    `| Regas / colheitas (média) | ${agg.waters} / ${agg.harvests} |`,
+    `| Combo máx | ${agg.maxCombo} |`,
+    `| Pedidos ativos (média) | ${agg.avgActiveOrders} |`,
+    `| Tempo parado | ${agg.idlePct}% |`,
+  ].join("\n");
+}
+
+function buildReport(runs, agg, tuning) {
+  const lines = [];
+  lines.push(`# Overgarden — Relatório de balanceamento (e2e)`);
+  lines.push("");
+  lines.push(`Bot autoplayer · dificuldade **${DIFF_LABEL[PLAYERS] || PLAYERS}** · ${runs.length} seeds · round de ${tuning.ROUND.duration}s.`);
+  lines.push("");
+  lines.push(`## Resumo`);
+  lines.push("");
+  lines.push(summaryTable(agg));
+  lines.push("");
+  lines.push(`### Como ler para rebalancear`);
+  lines.push(`- **Sempre 0★** → muito difícil (ou metas \`ROUND.stars\` altas demais). **Sempre 3★** → fácil demais.`);
+  lines.push(`- **Mortes altas / regas baixas** → \`TUNE.lifeBase\`/\`wiltGrace\` apertados ou velocidade insuficiente p/ cobrir o mapa.`);
+  lines.push(`- **Pedidos perdidos altos** → \`ORDER.timeBase\`/\`diffTime\` curtos ou \`spawn*\` rápidos demais.`);
+  lines.push(`- **Tempo parado alto** → bot sem tarefa: provável folga (pode apertar o tuning).`);
+  lines.push("");
+  lines.push(`## Score ao longo do round`);
+  lines.push("");
+  lines.push(`![score-over-time](./score-over-time.svg)`);
+  lines.push("");
+  lines.push(`## Evidência visual (seed ${EVIDENCE_SEED})`);
+  lines.push("");
+  const ev = runs.find((r) => r.seed === EVIDENCE_SEED);
+  for (const shot of ev?.shots || []) lines.push(`![${shot}](./${shot})`);
+  lines.push("");
+  lines.push(`## Por seed`);
+  lines.push("");
+  lines.push(`| seed | score | ★ | entreg. | perd. | mortas | regas | colh. | combo máx | parado% |`);
+  lines.push(`| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |`);
+  for (const r of runs) {
+    const s = r.summary;
+    lines.push(`| ${r.seed} | ${s.score} | ${s.stars} | ${s.delivered} | ${s.expired} | ${s.deaths} | ${s.waters} | ${s.harvests} | ${s.maxCombo} | ${s.idlePct} |`);
+  }
+  lines.push("");
+  lines.push(`## Tuning avaliado`);
+  lines.push("");
+  lines.push("```json");
+  lines.push(JSON.stringify(tuning, null, 2));
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function buildSummary(agg, tuning) {
+  const lines = [];
+  lines.push(`### 🌾 Overgarden — balanceamento e2e (${DIFF_LABEL[PLAYERS] || PLAYERS}, ${agg.runs} seeds)`);
+  lines.push("");
+  lines.push(summaryTable(agg));
+  lines.push("");
+  lines.push(`Metas de estrela: ${tuning.ROUND.stars.join(" / ")} · round ${tuning.ROUND.duration}s.`);
+  lines.push(`Evidências visuais (PNGs), gráfico SVG e \`metrics.json\` no artifact **overgarden-e2e** deste run.`);
+  return lines.join("\n");
+}
+
+// ---- main ------------------------------------------------------------------
+async function main() {
+  await rm(OUT, { recursive: true, force: true });
+  await mkdir(path.join(OUT, "screenshots"), { recursive: true });
+
+  const server = await startServer();
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const browser = await chromium.launch({ args: ["--no-sandbox"] });
+
+  const runs = [];
+  for (const seed of SEEDS) {
+    const r = await playRound(browser, base, seed, seed === EVIDENCE_SEED);
+    console.log(`seed ${seed}: score=${r.summary.score} stars=${r.summary.stars} delivered=${r.summary.delivered} expired=${r.summary.expired} deaths=${r.summary.deaths}`);
+    runs.push(r);
+  }
+
+  await browser.close();
+  server.close();
+
+  const tuning = runs[0].tuning;
+  const agg = aggregate(runs);
+
+  await writeFile(path.join(OUT, "score-over-time.svg"), buildChart(runs, tuning));
+  await writeFile(path.join(OUT, "metrics.json"), JSON.stringify({ players: PLAYERS, seeds: SEEDS, generatedAt: new Date().toISOString(), aggregate: agg, tuning, runs }, null, 2));
+  await writeFile(path.join(OUT, "report.md"), buildReport(runs, agg, tuning));
+  await writeFile(path.join(OUT, "summary.md"), buildSummary(agg, tuning));
+
+  console.log(`\nAggregate: score mean=${agg.score.mean} median=${agg.score.median} | stars 0/1/2/3 = ${agg.starDistribution["0"]}/${agg.starDistribution["1"]}/${agg.starDistribution["2"]}/${agg.starDistribution["3"]} | avgStars=${agg.avgStars}`);
+  console.log(`Wrote report to ${OUT}`);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/web/game.js
+++ b/web/game.js
@@ -52,6 +52,22 @@ const ORDER = {
   comboWindow: 12,          // seconds before an idle combo resets
 };
 
+// Seedable RNG — only gameplay-affecting randomness (order stream) routes
+// through rng() so headless runs with ?seed=N are reproducible. Visual-only
+// randomness (particles) stays on Math.random and never affects metrics.
+let _seedRng = null;
+function rng() { return _seedRng ? _seedRng() : Math.random(); }
+function seedRng(seed) {
+  // mulberry32 — tiny, deterministic PRNG.
+  let a = (seed >>> 0) || 1;
+  _seedRng = function () {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
 // Built once assets load: PLANTS list sorted by rarity (SeedStallManager order).
 let PLANTS = [];
 
@@ -272,11 +288,11 @@ function spawnOrder() {
   if (game.orders.length >= ORDER.maxConcurrent) return;
   const maxR = orderableRarity();
   const pool = PLANTS.filter((p) => p.rarity <= maxR);
-  const plant = pool[Math.floor(Math.random() * pool.length)];
+  const plant = pool[Math.floor(rng() * pool.length)];
   const p = roundProgress();
   let qty = 1;
-  if (p > 0.3 && Math.random() < 0.5) qty++;
-  if (p > 0.6 && Math.random() < 0.4) qty++;
+  if (p > 0.3 && rng() < 0.5) qty++;
+  if (p > 0.6 && rng() < 0.4) qty++;
   const time = (ORDER.timeBase + ORDER.timePerRarity * plant.rarity) * ORDER.diffTime[game.numberOfPlayers - 1];
   game.orders.push({ plant, need: qty, qty, timeLeft: time, maxTime: time, id: game.orderId++ });
 }
@@ -1134,16 +1150,49 @@ ctx.fillStyle = "#6ab04c";
 ctx.fillRect(0, 0, WORLD.w, WORLD.h);
 
 if (location.search.includes("debug")) {
+  const params = new URLSearchParams(location.search);
+  if (params.has("seed")) seedRng(parseInt(params.get("seed"), 10));
+
   window.__OG__ = {
     get game() { return game; },
     get gameState() { return gameState; },
     get PLANTS() { return PLANTS; },
+    // Constants exposed so the harness reports against live tuning values.
+    TUNE, ROUND, ORDER, WORLD, HOLD, STAGE,
+    // Raw input maps so an external bot can drive via the same input path the
+    // human uses (movement runs at real game speed — realistic for balancing).
+    keys, justPressed,
     teleport(x, y) { game.player.x = x; game.player.y = y; },
     openSeedMenu(i = 0) { game.seedMenu.open = true; game.seedMenu.index = i; },
     setPlot(i, patch) { Object.assign(game.plots[i], patch); },
     setTime(t) { game.time = t; },
     spawnOrder,
     addScore(n) { game.score += n; },
+    seedRng,
+    assetsReady() { return !!ASSETS.atlas && PLANTS.length > 0; },
+    // Start a round without the rAF loop or audio; the harness drives time via
+    // tick(dt) so a 150s round runs deterministically in a fraction of a second.
+    startHeadless({ players = 1, seed = null } = {}) {
+      if (seed != null) seedRng(seed);
+      selectedPlayers = players;
+      sound.setMuted(true);
+      game = createGame(players);
+      gameState = "playing";
+      running = false;
+      startScreen.classList.add("hidden");
+      pauseScreen.classList.add("hidden");
+      resultScreen.classList.add("hidden");
+      return true;
+    },
+    // One deterministic frame. Mirrors loop() but with a caller-supplied dt and
+    // optional rendering (skip it for fast data-only runs).
+    tick(dt, doRender = false) {
+      if (pressed("p") && gameState === "playing") togglePause();
+      update(dt);
+      if (doRender && game) render();
+      clearJustPressed();
+      return gameState;
+    },
   };
 }
 


### PR DESCRIPTION
## O que é

Um **bot autoplayer** que joga rounds headless determinísticos do jogo web e, a cada PR, produz **evidência visual** + **dados pra rebalancear**.

Como o jogo já expõe `?debug` (`window.__OG__`) e tem `update(dt)` determinístico, o harness aproveita isso: o bot joga pela **mesma via de input do humano** (seta `keys`/`justPressed`), em **velocidade real de jogo** — então os dados refletem se um jogador competente consegue acompanhar o tuning atual.

## Como funciona

1. Serve `web/` em Chromium headless com `?debug&seed=N`.
2. Injeta `bot.js` (heurística: preparar → plantar → regar → colher → entregar, priorizando pedidos urgentes e plantas murchando).
3. `tick(dt)` semeado avança um round de 150s numa fração de segundo; `harness.js` grava métricas tick a tick.
4. `run.mjs` roda vários seeds e escreve em `tests/e2e/out/`:
   - `screenshots/*.png` — começo / meio / fim / resultado
   - `score-over-time.svg` — curvas de score vs. metas de estrela
   - `metrics.json` — cada run + agregado + snapshot do tuning avaliado
   - `report.md` (completo) e `summary.md` (tabela do comentário)

## CI

`.github/workflows/e2e-evidence.yml` roda em PR que toca `web/**`/`tests/**`, joga **Fácil e Insano (5 seeds cada)**, sobe o artifact **overgarden-e2e** e posta/atualiza um comentário com a tabela de balanceamento.

## Mudanças no jogo (atrás de `?debug`, produção intacta)

- RNG **semeável** (`?seed=`) só na aleatoriedade de gameplay (stream de pedidos) → runs reproduzíveis.
- API headless no `__OG__`: `startHeadless`, `tick(dt, render)`, acesso a `keys`/`justPressed`, constantes de tuning.

## Primeiro sinal de balanceamento 📊

Rodando localmente (Fácil, solo), o bot competente:
- mantém **1 cultivo vivo** (0 mortes), rega ~18×, **entrega ~3 pedidos**;
- mas **~12 pedidos surgem e ~6 expiram** (−60 cada) → score zera.

Ou seja: um único runner não dá conta da vazão de pedidos exigida, e as penalidades de expiração anulam o score. Candidatos a ajustar: `ORDER.spawn*`/`timeBase`, `expirePenalty`, distância até o poço, ou `ROUND.stars`. (Co-op resolveria parte disso.)

## Rodar local

```bash
npm install
npx playwright install --with-deps chromium
npm run e2e            # Fácil, seeds 1..5
open tests/e2e/out/report.md
```

Draft até validarmos o formato do comentário/artifact num PR real.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_