### PR TITLE
e2e: sweep com modo production — mede o ganho de acelerar produção

### DIFF
--- a/.github/workflows/tuning-sweep.yml
+++ b/.github/workflows/tuning-sweep.yml
@@ -6,6 +6,11 @@ name: tuning sweep (manual)
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Modo de varredura"
+        type: choice
+        options: ["order", "production"]
+        default: "order"
       players:
         description: "Dificuldade (1=Fácil … 4=Insano)"
         default: "1"
@@ -30,11 +35,11 @@ jobs:
       - run: npm install
       - run: npx playwright install --with-deps chromium
       - name: Sweep
-        run: node tests/e2e/sweep.mjs --players ${{ inputs.players }} --seeds ${{ inputs.seeds }} --target ${{ inputs.target }}
+        run: node tests/e2e/sweep.mjs --mode ${{ inputs.mode }} --players ${{ inputs.players }} --seeds ${{ inputs.seeds }} --target ${{ inputs.target }}
       - name: Print report
-        run: cat tests/e2e/out/sweep/sweep.md >> "$GITHUB_STEP_SUMMARY"
+        run: cat tests/e2e/out/sweep-${{ inputs.mode }}/sweep.md >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         with:
-          name: overgarden-tuning-sweep
-          path: tests/e2e/out/sweep
+          name: overgarden-tuning-sweep-${{ inputs.mode }}
+          path: tests/e2e/out/sweep-${{ inputs.mode }}
           if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e:easy": "node tests/e2e/run.mjs --players 1",
     "e2e:insane": "node tests/e2e/run.mjs --players 4",
     "sweep": "node tests/e2e/sweep.mjs",
+    "sweep:prod": "node tests/e2e/sweep.mjs --mode production",
     "sweep:insane": "node tests/e2e/sweep.mjs --players 4"
   },
   "devDependencies": {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -47,14 +47,18 @@ knobs and let the bot tell you which combo lands a competent player in the
 "fun" star band:
 
 ```bash
-npm run sweep                                  # Fácil, 18 combos × 3 seeds
-node tests/e2e/sweep.mjs --players 4 --target 1.5
-open tests/e2e/out/sweep/sweep.md
+npm run sweep                                  # modo order (pacing de pedidos)
+npm run sweep:prod                             # modo production (crescimento + vida)
+node tests/e2e/sweep.mjs --mode production --players 4 --target 1.5
+open tests/e2e/out/sweep-production/sweep.md
 ```
 
-Swept axes (in `sweep.mjs`, all relative to the shipped baseline):
-`spawnScale` (order spawn rate), `ORDER.timeBase` (deadline), `ORDER.expirePenalty`.
-It mutates the live `__OG__.ORDER` object before each round — no rebuild needed.
+Two modes (`--mode`), all axes relative to the shipped baseline:
+
+- **order** (default): `spawnScale` (spawn rate), `ORDER.timeBase` (deadline), `ORDER.expirePenalty`.
+- **production**: `growthScale` (`TUNE.growthBase`, <1 = matures faster), `lifeScale` (`TUNE.lifeBase`, >1 = wilts slower → fewer well trips).
+
+It mutates the live `__OG__.ORDER` / `__OG__.TUNE` objects before each round — no rebuild needed.
 
 The report ranks combos, flags those in the band, and — crucially — reports the
 **achievable score ceiling**: if the lowest `ROUND.stars` threshold sits above

--- a/tests/e2e/sweep.mjs
+++ b/tests/e2e/sweep.mjs
@@ -1,13 +1,18 @@
 // Overgarden tuning sweep.
 //
-// Sweeps combinations of the balancing knobs that most affect throughput and
-// runs the autoplayer bot across several seeds per combo, then ranks which
-// combos land a competent player in the "fun" star band (default 1–2★).
+// Sweeps combinations of balancing knobs and runs the autoplayer bot across
+// several seeds per combo, then ranks which combos land a competent player in
+// the "fun" star band (default 1–2★) and reports the achievable score ceiling.
+//
+// Two modes (--mode):
+//   order      (default) — order pacing: spawn rate, deadline, expire penalty
+//   production           — crop economy: growth speed, life duration (watering)
 //
 // It mutates the live __OG__.TUNE/ORDER/ROUND objects in-page before each round
-// (they're const bindings but mutable objects), so no rebuild is needed.
+// (const bindings, mutable objects), so no rebuild is needed.
 //
-// Usage: node tests/e2e/sweep.mjs [--players N] [--seeds 1,2,3] [--target 1.5] [--out DIR]
+// Usage: node tests/e2e/sweep.mjs [--mode order|production] [--players N]
+//        [--seeds 1,2,3] [--target 1.5] [--out DIR]
 import { chromium } from "playwright";
 import http from "node:http";
 import { readFile, mkdir, writeFile, rm } from "node:fs/promises";
@@ -19,24 +24,57 @@ const WEB_DIR = path.resolve(HERE, "../../web");
 
 const argv = process.argv.slice(2);
 const getArg = (n, d) => { const i = argv.indexOf(n); return i >= 0 && argv[i + 1] ? argv[i + 1] : d; };
+const MODE = getArg("--mode", "order");
 const PLAYERS = parseInt(getArg("--players", "1"), 10);
 const SEEDS = getArg("--seeds", "1,2,3").split(",").map((s) => parseInt(s, 10));
 const TARGET = parseFloat(getArg("--target", "1.5")); // ideal avg stars (centre of fun band)
 const BAND = [1, 2];                                  // fun band (inclusive)
-const OUT = path.resolve(process.cwd(), getArg("--out", "tests/e2e/out/sweep"));
+const OUT = path.resolve(process.cwd(), getArg("--out", `tests/e2e/out/sweep-${MODE}`));
 
-// ---- swept axes ------------------------------------------------------------
-// Each axis is expressed relative to the shipped baseline so the grid stays
-// meaningful even if defaults change. spawnScale > 1 = orders spawn slower.
-const AXES = {
-  spawnScale: [1.0, 1.5, 2.0],   // multiplies ORDER.spawnStart / spawnEnd
-  timeBase: [22, 32, 42],        // ORDER.timeBase (seconds to fulfil)
-  expirePenalty: [60, 30],       // ORDER.expirePenalty
+// ---- sweep modes -----------------------------------------------------------
+// Axis value arrays list the shipped baseline FIRST, so the ranking can prefer
+// the least-disruptive combo on ties. Scale axes multiply the baseline value.
+const MODES = {
+  order: {
+    title: "pacing de pedidos",
+    axes: { spawnScale: [1.0, 1.5, 2.0], timeBase: [22, 32, 42], expirePenalty: [60, 30] },
+    headers: ["spawn×", "timeBase", "expirePen"],
+    patch: (c, b) => ({
+      ORDER: {
+        spawnStart: +(b.ORDER.spawnStart * c.spawnScale).toFixed(2),
+        spawnEnd: +(b.ORDER.spawnEnd * c.spawnScale).toFixed(2),
+        timeBase: c.timeBase,
+        expirePenalty: c.expirePenalty,
+      },
+    }),
+    label: (c) => `spawn×${c.spawnScale} time=${c.timeBase} pen=${c.expirePenalty}`,
+    rec: (r, b) => `\`spawnScale ${r.spawnScale}\` · \`ORDER.timeBase ${r.timeBase}\` · \`ORDER.expirePenalty ${r.expirePenalty}\``,
+  },
+  production: {
+    title: "economia de cultivo (crescimento + vida)",
+    // growthScale < 1 = matura mais rápido; lifeScale > 1 = seca mais devagar
+    // (menos idas ao poço, dá pra cuidar de mais canteiros).
+    axes: { growthScale: [1.0, 0.75, 0.5], lifeScale: [1.0, 1.5, 2.0] },
+    headers: ["growth×", "life×", "(growthBase)", "(lifeBase)"],
+    extra: (c, b) => [+(b.TUNE.growthBase * c.growthScale).toFixed(3), +(b.TUNE.lifeBase * c.lifeScale).toFixed(3)],
+    patch: (c, b) => ({
+      TUNE: {
+        growthBase: +(b.TUNE.growthBase * c.growthScale).toFixed(3),
+        lifeBase: +(b.TUNE.lifeBase * c.lifeScale).toFixed(3),
+      },
+    }),
+    label: (c) => `growth×${c.growthScale} life×${c.lifeScale}`,
+    rec: (r, b) => `\`growthScale ${r.growthScale}\` (TUNE.growthBase ${+(b.TUNE.growthBase * r.growthScale).toFixed(3)}) · \`lifeScale ${r.lifeScale}\` (TUNE.lifeBase ${+(b.TUNE.lifeBase * r.lifeScale).toFixed(3)})`,
+  },
 };
+
+const M = MODES[MODE];
+if (!M) { console.error(`Modo desconhecido: ${MODE}. Use 'order' ou 'production'.`); process.exit(1); }
+const AXIS_KEYS = Object.keys(M.axes);
 
 function product() {
   let combos = [{}];
-  for (const [key, vals] of Object.entries(AXES)) {
+  for (const [key, vals] of Object.entries(M.axes)) {
     const next = [];
     for (const c of combos) for (const v of vals) next.push({ ...c, [key]: v });
     combos = next;
@@ -75,26 +113,21 @@ async function main() {
   await page.addScriptTag({ path: path.join(HERE, "bot.js") });
   await page.addScriptTag({ path: path.join(HERE, "harness.js") });
 
-  // Capture shipped baseline (for relative axes) and report-against tuning.
-  const baseline = await page.evaluate(() => ({ ORDER: { ...window.__OG__.ORDER }, ROUND: { ...window.__OG__.ROUND } }));
+  const baseline = await page.evaluate(() => ({
+    ORDER: { ...window.__OG__.ORDER }, ROUND: { ...window.__OG__.ROUND }, TUNE: { ...window.__OG__.TUNE },
+  }));
 
   const combos = product();
-  console.log(`Sweeping ${combos.length} combos × ${SEEDS.length} seeds (dificuldade ${PLAYERS})…\n`);
+  console.log(`Sweep [${MODE}: ${M.title}] — ${combos.length} combos × ${SEEDS.length} seeds (dificuldade ${PLAYERS})…\n`);
 
   const results = [];
   for (const combo of combos) {
-    const patch = {
-      ORDER: {
-        spawnStart: +(baseline.ORDER.spawnStart * combo.spawnScale).toFixed(2),
-        spawnEnd: +(baseline.ORDER.spawnEnd * combo.spawnScale).toFixed(2),
-        timeBase: combo.timeBase,
-        expirePenalty: combo.expirePenalty,
-      },
-    };
+    const patch = M.patch(combo, baseline);
     const runs = [];
     for (const seed of SEEDS) {
       const m = await page.evaluate(({ patch, players, seed }) => {
-        Object.assign(window.__OG__.ORDER, patch.ORDER);
+        if (patch.ORDER) Object.assign(window.__OG__.ORDER, patch.ORDER);
+        if (patch.TUNE) Object.assign(window.__OG__.TUNE, patch.TUNE);
         window.__OG_HARNESS__.start({ players, seed });
         window.__OG_HARNESS__.run({ untilTime: 0, render: false });
         return window.__OG_HARNESS__.metrics().summary;
@@ -111,61 +144,68 @@ async function main() {
     };
     agg.inBand = agg.avgStars >= BAND[0] && agg.avgStars <= BAND[1];
     results.push(agg);
-    console.log(`spawn×${combo.spawnScale} time=${combo.timeBase} pen=${combo.expirePenalty} -> score=${agg.meanScore} stars=${agg.avgStars} exp=${agg.expired}${agg.inBand ? "  ✓band" : ""}`);
+    console.log(`${M.label(combo)} -> score=${agg.meanScore} stars=${agg.avgStars} exp=${agg.expired} deaths=${agg.deaths}${agg.inBand ? "  ✓band" : ""}`);
   }
 
   await browser.close();
   server.close();
 
-  // Rank: in-band first, then closeness to TARGET, then higher score, then the
-  // smallest deviation from shipped defaults (least disruptive change).
-  const dev = (c) => Math.abs(c.spawnScale - 1) + Math.abs(c.timeBase - baseline.ORDER.timeBase) / 10 + Math.abs(c.expirePenalty - baseline.ORDER.expirePenalty) / 30;
+  // Rank: in-band first, then closeness to TARGET, higher score, and finally the
+  // least-disruptive combo (axis values nearest the shipped baseline = index 0).
+  const dev = (c) => AXIS_KEYS.reduce((s, k) => s + M.axes[k].indexOf(c[k]), 0);
   const ranked = [...results].sort((a, b) =>
     (b.inBand - a.inBand) ||
     (Math.abs(a.avgStars - TARGET) - Math.abs(b.avgStars - TARGET)) ||
     (b.meanScore - a.meanScore) ||
     (dev(a) - dev(b))
   );
-
-  const md = [];
-  md.push(`# Tuning sweep — dificuldade ${PLAYERS} (${SEEDS.length} seeds/combo)`);
-  md.push("");
-  md.push(`Faixa-alvo: **${BAND[0]}–${BAND[1]}★** (ideal ${TARGET}). Metas de estrela: ${baseline.ROUND.stars.join(" / ")} · round ${baseline.ROUND.duration}s.`);
-  md.push(`Baseline atual: spawn ${baseline.ORDER.spawnStart}→${baseline.ORDER.spawnEnd}s, timeBase ${baseline.ORDER.timeBase}s, expirePenalty ${baseline.ORDER.expirePenalty}.`);
-  md.push("");
   const rec = ranked[0];
+  const baselineCombo = results.find((r) => AXIS_KEYS.every((k) => r[k] === M.axes[k][0]));
 
-  // Achievable ceiling: best mean score any combo reached. If the lowest star
-  // threshold sits above it, no tuning of the order knobs alone can earn a star
-  // — the thresholds must come down (or production must speed up / go co-op).
   const ceiling = Math.max(...results.map((r) => r.meanScore));
   const suggestedStars = [Math.round(ceiling * 0.5), Math.round(ceiling * 0.8), Math.round(ceiling * 1.05)];
 
-  md.push(`## Teto de score`);
-  md.push(`Maior score médio alcançado no sweep: **${ceiling}**. Meta de 1★ atual: **${baseline.ROUND.stars[0]}**.`);
-  if (ceiling < baseline.ROUND.stars[0]) {
-    md.push(`> ⚠️ O teto está **abaixo** da meta de 1★ — nenhum ajuste de spawn/prazo/penalidade sozinho dá estrela a um jogador solo.`);
-    md.push(`> Sugestão de metas alinhadas ao teto: \`ROUND.stars = [${suggestedStars.join(", ")}]\` (≈50% / 80% / 105% do teto), ou acelerar produção (crescimento/poço) ou co-op.`);
+  // ---- report --------------------------------------------------------------
+  const md = [];
+  md.push(`# Tuning sweep — modo \`${MODE}\` (${M.title})`);
+  md.push("");
+  md.push(`Dificuldade ${PLAYERS} · ${SEEDS.length} seeds/combo · faixa-alvo **${BAND[0]}–${BAND[1]}★** (ideal ${TARGET}).`);
+  md.push(`Metas de estrela: ${baseline.ROUND.stars.join(" / ")} · round ${baseline.ROUND.duration}s.`);
+  if (baselineCombo) md.push(`**Baseline atual** (sem mudança): score **${baselineCombo.meanScore}** · ${baselineCombo.avgStars}★ · ${baselineCombo.expired} perdidos · ${baselineCombo.deaths} mortas.`);
+  md.push("");
+
+  md.push(`## Recomendação`);
+  if (rec.inBand) {
+    const gain = baselineCombo ? ` (baseline: ${baselineCombo.meanScore} / ${baselineCombo.avgStars}★)` : "";
+    md.push(`${M.rec(rec, baseline)} → **${rec.avgStars}★**, score ${rec.meanScore}, ${rec.expired} perdidos${gain}.`);
   } else {
-    md.push(`Metas \`ROUND.stars\` parecem alcançáveis; foque no ranking de combos abaixo.`);
+    md.push(`Nenhum combo entrou na faixa ${BAND[0]}–${BAND[1]}★. Melhor aproximação: ${M.rec(rec, baseline)} → ${rec.avgStars}★ (score ${rec.meanScore}). Considere combinar com o outro modo ou baixar \`ROUND.stars\`.`);
   }
   md.push("");
-  md.push(`## Recomendação`);
-  md.push(rec.inBand
-    ? `\`spawnScale ${rec.spawnScale}\` · \`timeBase ${rec.timeBase}\` · \`expirePenalty ${rec.expirePenalty}\` → **${rec.avgStars}★** (score ${rec.meanScore}, ${rec.expired} pedidos perdidos).`
-    : `Nenhum combo entrou na faixa ${BAND[0]}–${BAND[1]}★. Melhor aproximação: \`spawnScale ${rec.spawnScale}\` · \`timeBase ${rec.timeBase}\` · \`expirePenalty ${rec.expirePenalty}\` → ${rec.avgStars}★. Considere também baixar \`ROUND.stars\` ou ampliar o sweep.`);
-  md.push("");
-  md.push(`## Ranking`);
-  md.push(`| # | spawn× | timeBase | expirePen | score méd | ★ méd | entreg | perdidos | mortas | faixa |`);
-  md.push(`| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |`);
-  ranked.forEach((r, i) => md.push(`| ${i + 1} | ${r.spawnScale} | ${r.timeBase} | ${r.expirePenalty} | ${r.meanScore} | ${r.avgStars} | ${r.delivered} | ${r.expired} | ${r.deaths} | ${r.inBand ? "✅" : ""} |`));
 
-  await writeFile(path.join(OUT, "sweep.json"), JSON.stringify({ players: PLAYERS, seeds: SEEDS, target: TARGET, band: BAND, baseline, axes: AXES, ceiling, suggestedStars, ranked }, null, 2));
+  md.push(`## Teto de score`);
+  md.push(`Maior score médio no sweep: **${ceiling}** (baseline ${baselineCombo ? baselineCombo.meanScore : "?"}). Meta de 1★: **${baseline.ROUND.stars[0]}**.`);
+  if (ceiling < baseline.ROUND.stars[0]) {
+    md.push(`> ⚠️ Teto abaixo de 1★. Sugestão de metas: \`ROUND.stars = [${suggestedStars.join(", ")}]\`, ou combinar com o modo \`order\`/co-op.`);
+  }
+  md.push("");
+
+  const head = ["#", ...M.headers, "score méd", "★ méd", "entreg", "perdidos", "mortas", "faixa"];
+  md.push(`## Ranking`);
+  md.push(`| ${head.join(" | ")} |`);
+  md.push(`| ${head.map(() => "---").join(" | ")} |`);
+  ranked.forEach((r, i) => {
+    const extra = M.extra ? M.extra(r, baseline) : [];
+    const cells = [i + 1, ...AXIS_KEYS.map((k) => r[k]), ...extra, r.meanScore, r.avgStars, r.delivered, r.expired, r.deaths, r.inBand ? "✅" : ""];
+    md.push(`| ${cells.join(" | ")} |`);
+  });
+
+  await writeFile(path.join(OUT, "sweep.json"), JSON.stringify({ mode: MODE, players: PLAYERS, seeds: SEEDS, target: TARGET, band: BAND, baseline, axes: M.axes, ceiling, suggestedStars, baselineCombo, ranked }, null, 2));
   await writeFile(path.join(OUT, "sweep.md"), md.join("\n"));
   console.log(`\nWrote sweep report to ${OUT}`);
   console.log(rec.inBand
-    ? `Recommended: spawnScale=${rec.spawnScale} timeBase=${rec.timeBase} expirePenalty=${rec.expirePenalty} (${rec.avgStars}★)`
-    : `No combo in band; best ${rec.avgStars}★ at spawnScale=${rec.spawnScale} timeBase=${rec.timeBase} expirePenalty=${rec.expirePenalty}`);
+    ? `Recommended [${MODE}]: ${M.label(rec)} -> ${rec.avgStars}★ (score ${rec.meanScore}, baseline ${baselineCombo ? baselineCombo.meanScore : "?"})`
+    : `No combo in band; best ${rec.avgStars}★ at ${M.label(rec)} (score ${rec.meanScore})`);
 }
 
 main().catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## O que é

Generaliza o tuning sweep em **modos** e adiciona o modo **production** pra medir o ganho da opção 2 (acelerar produção), sem ainda alterar o tuning do jogo.

- **order** (default, comportamento anterior): pacing de pedidos.
- **production** (novo): varre `growthScale` (`TUNE.growthBase`, <1 = matura mais rápido) e `lifeScale` (`TUNE.lifeBase`, >1 = seca mais devagar → menos idas ao poço). Muta `__OG__.TUNE` ao vivo.

O relatório agora mostra o **combo baseline** e o **ganho relativo**.

## 📊 Resultado do sweep de produção (Fácil, 5 seeds, metas 100/150/200)

| growth× | life× | score méd | ★ méd | mortas | |
|---|---|---|---|---|---|
| 1 | 1 | **74** | 0.6 | 1.6 | baseline |
| 1 | 1.5 | 192 | 1.2 | 0 | ✅ faixa |
| 1 | 2 | 176 | 1.4 | 0 | ✅ faixa |
| 0.75 | 1 | 172 | 1.2 | 1.6 | ✅ faixa |
| 0.75 | 1.5 | 406 | 3 | 0 | |
| 0.5 | * | ~640 | 3 | 0 | |

**Leitura:** produção é a maior alavanca. Só fazer a planta **secar mais devagar** (`life×1.5`, ou seja `TUNE.lifeBase` 1.13→1.7) já **quase triplica o score (74→192)** e zera mortes — o gargalo do solo eram as idas ao poço. `growth×0.75 + life×1.5` leva a **3★** limpo. `growth×0.5` satura em ~640 (provavelmente rápido demais / fácil demais).

## Como rodar

```bash
npm run sweep:prod          # production, Fácil
node tests/e2e/sweep.mjs --mode production --players 2
```

Também via **Actions → tuning sweep (manual)** (agora com input de modo `order`/`production`).

## Próximo passo (sua decisão)

Não apliquei mudança de tuning ainda — isso era pra **ver o ganho**. Candidato mais equilibrado: **`lifeScale 1.5`** (1.2★, 0 mortes, mínimo de mudança), opcionalmente com `growthScale 0.75` se quiser mirar 2–3★. Quer que eu aplique algum desses e re-verifique com o harness?

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_