### PR TITLE
balance: produção mais rápida (lifeBase) + metas de estrela recalibradas

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -38,8 +38,8 @@ const TUNE = {
 const ROUND = {
   duration: 150,          // seconds
   // Calibrated to the achievable ceiling measured by the e2e bot at the shipped
-  // pacing (~50/80/105% of a competent solo run's best). See tests/e2e/.
-  stars: [100, 150, 200], // score thresholds for 1/2/3 stars
+  // pacing: 1★ ≈ a median solo run, 3★ ≈ a strong one. See tests/e2e/.
+  stars: [90, 200, 380], // score thresholds for 1/2/3 stars
 };
 
 const ORDER = {

--- a/web/game.js
+++ b/web/game.js
@@ -28,7 +28,7 @@ const TUNE = {
   idleRegen: 26,
   // Life runs out before a growth stage completes, so plants need watering.
   growthBase: 1.1,   // * rarity * mult => seconds to complete a growth stage
-  lifeBase: 0.85,    // * rarity * mult => seconds of life (< growth => must water)
+  lifeBase: 1.3,     // * rarity * mult => seconds of life (< growth => must water)
   wiltGrace: 3.0,    // seconds a plant can wilt (life 0) before dying — reversible
   decayRampMin: 0.6, // life-decay multiplier at round start (forgiving)
   decayRampMax: 1.3, // ...and at round end (harsher)


### PR DESCRIPTION
## O que muda

Dois ajustes guiados pelos dados do harness e2e, para tornar o modo solo recompensador:

1. **`TUNE.lifeBase 0.85 → 1.3`** — planta seca ~1.5× mais devagar entre regas. O gargalo do solo eram as idas ao poço; o sweep de produção apontou essa como a maior alavanca de menor disrupção.
2. **`ROUND.stars [100,150,200] → [90,200,380]`** — com a produção mais rápida o teto subiu pra ~394, então as metas foram remapeadas para **recompensar o run típico**: 1★ ≈ mediana, 3★ ≈ melhor run.

## Verificação (bot, Fácil, 5 seeds)

| | antes | depois |
|---|---|---|
| Score médio | 74 | **192** |
| Mortes/round | 1.6 | **0** |
| Scores por seed | 0,0,30,149,192 | 60,84,90,333,394 |
| Distribuição ★ (0/1/2/3) | 3/1/1/0 | **2/1/1/1** |

A distribuição final é uma curva suave cobrindo todos os níveis de estrela — runs ruins ainda ficam em 0★ (espaço pra melhorar), runs medianos pegam 1★, e bons runs 2–3★. O Insano também melhorou de tabela (combo máx subiu pra 4).

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd