### PR TITLE
balance(co-op): metas por throughput medido + harness multi-bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "e2e:insane": "node tests/e2e/run.mjs --players 4",
     "sweep": "node tests/e2e/sweep.mjs",
     "sweep:prod": "node tests/e2e/sweep.mjs --mode production",
-    "sweep:insane": "node tests/e2e/sweep.mjs --players 4"
+    "sweep:insane": "node tests/e2e/sweep.mjs --players 4",
+    "coop": "node tests/e2e/coop.mjs"
   },
   "devDependencies": {
     "playwright": "^1.49.0"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -67,6 +67,29 @@ aligned to the ceiling (or points to speeding up production / co-op).
 
 Can also be run on demand from the **Actions → tuning-sweep** workflow.
 
+## Co-op balancing
+
+Drives N bot players (1–4) on the shared farm and reports team score, star
+distribution and load per player count, so the `COOP` scaling in `game.js`
+(spawn rate, concurrent orders, star goals) can be tuned to real multi-player
+throughput:
+
+```bash
+npm run coop                                   # difficulty Fácil, counts 1–4
+node tests/e2e/coop.mjs --difficulty 2 --counts 2,4
+open tests/e2e/out/coop/coop.md
+```
+
+The co-op bot (`coop-bot.js`) is intent-based and claims plots so players divide
+labour. It's a *stronger* proxy than the solo bot, so it's used for **relative**
+throughput ratios across counts (`starScale = teto_N / teto_solo`), not absolute
+goals. Throughput scales **sublinearly** (shared plots + one well), which is why
+`COOP.starScale` is ~`[1, 1.8, 2.1, 2.6]` rather than `[1, 2, 3, 4]`.
+
+> Headless co-op runs via `__OG__.startHeadlessCoop({count,difficulty,seed})` +
+> `setBotIntents()` — a separate path from the solo harness, so the per-PR e2e
+> is untouched.
+
 ## Reproducibility
 
 Only gameplay-affecting randomness (the order stream) is seeded via a mulberry32

--- a/tests/e2e/coop-bot.js
+++ b/tests/e2e/coop-bot.js
@@ -1,0 +1,122 @@
+"use strict";
+/*
+ * Co-op autoplayer — drives N player slots for headless balancing of co-op
+ * tuning. Same heuristic as the solo bot, but it emits an `intent` per player
+ * (not keyboard) and players claim plots so they divide labour instead of all
+ * piling onto the same crop.
+ *
+ * Discrete actions (interact / menu nav / confirm) are pulsed with a per-player
+ * cooldown so a held intent doesn't spam the action every tick.
+ *
+ * Injected by coop.mjs; attaches window.__OG_COOPBOT__.intents(OG) -> intent[].
+ */
+(function () {
+  const ZERO = () => ({ mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false });
+  const state = {}; // per-player: { cd, navCd, wantSeed }
+
+  function st(i) { return state[i] || (state[i] = { cd: 0, navCd: 0, wantSeed: 0 }); }
+
+  window.__OG_COOPBOT__ = {
+    reset() { for (const k in state) delete state[k]; },
+    intents(OG) {
+      const g = OG.game;
+      if (!g) return [];
+      const H = OG.HOLD, S = OG.STAGE;
+      const reach = OG.TUNE.interactRadius * 0.7;
+      const growing = (pl) => pl.stage >= S.SMALL && pl.stage < S.READY;
+      const station = (t) => g.stations.find((s) => s.type === t);
+      const orderNeed = (name) => g.orders.filter((o) => o.plant.name === name && o.need > 0).reduce((a, o) => a + o.need, 0);
+      const claimed = new Set(); // plot indices taken by earlier players this tick
+      const out = [];
+
+      for (let i = 0; i < g.players.length; i++) {
+        const p = g.players[i], s = st(i);
+        if (s.cd > 0) s.cd--;
+        if (s.navCd > 0) s.navCd--;
+        const it = ZERO();
+        const d2 = (x, y) => Math.hypot(p.x - x, p.y - y);
+
+        // --- Seed menu: navigate to wanted plant, then confirm (pulsed). ---
+        if (p.seedMenu.open) {
+          if (s.navCd <= 0 && p.seedMenu.index !== s.wantSeed) {
+            if (p.seedMenu.index < s.wantSeed) it.navR = true; else it.navL = true;
+            s.navCd = 4;
+          } else if (p.seedMenu.index === s.wantSeed && s.cd <= 0) {
+            it.confirm = true; s.cd = 6;
+          }
+          out.push(it);
+          continue;
+        }
+
+        // Nearest plot matching pred that isn't already claimed this tick.
+        const pickPlot = (pred) => {
+          let best = -1, bd = Infinity;
+          for (let k = 0; k < g.plots.length; k++) {
+            if (claimed.has(k) || !pred(g.plots[k])) continue;
+            const d = d2(g.plots[k].x, g.plots[k].y);
+            if (d < bd) { bd = d; best = k; }
+          }
+          return best;
+        };
+
+        // Move toward (x,y); when in reach, pulse interact. Returns true if acting.
+        const go = (x, y) => {
+          const d = d2(x, y);
+          if (d > reach) {
+            const dx = x - p.x, dy = y - p.y;
+            it.mx = Math.abs(dx) < 6 ? 0 : Math.max(-1, Math.min(1, dx / 40));
+            it.my = Math.abs(dy) < 6 ? 0 : Math.max(-1, Math.min(1, dy / 40));
+            it.run = d > 200 && p.stamina > 25;
+            return false;
+          }
+          if (s.cd <= 0) { it.interact = true; s.cd = 6; }
+          return true;
+        };
+        const goPlot = (k) => { claimed.add(k); return go(g.plots[k].x, g.plots[k].y); };
+
+        // --- Act on held item. ---
+        if (p.holding === H.PLANT) { go(station("sales").x, station("sales").y); out.push(it); continue; }
+        if (p.holding === H.TOOL) {
+          const k = pickPlot((x) => x.stage === S.DIED); const k2 = k >= 0 ? k : pickPlot((x) => x.stage === S.VIRGIN);
+          if (k2 >= 0) goPlot(k2); else if (s.cd <= 0) { it.drop = true; s.cd = 6; }
+          out.push(it); continue;
+        }
+        if (p.holding === H.WATER) {
+          const k = pickPlot((x) => growing(x) && (x.wilt > 0 || x.life < 0.6));
+          if (k >= 0) goPlot(k); else if (s.cd <= 0) { it.drop = true; s.cd = 6; }
+          out.push(it); continue;
+        }
+        if (p.holding === H.SEED) {
+          const k = pickPlot((x) => x.stage === S.TREATED);
+          if (k >= 0) goPlot(k); else if (s.cd <= 0) { it.drop = true; s.cd = 6; }
+          out.push(it); continue;
+        }
+
+        // --- Hands empty: pick the highest-value task (unclaimed). ---
+        const wilting = pickPlot((x) => growing(x) && x.wilt > 0);
+        if (wilting >= 0) { claimed.add(wilting); go(station("water").x, station("water").y); out.push(it); continue; }
+        const ready = pickPlot((x) => x.stage === S.READY && orderNeed(x.plant.name) > 0);
+        if (ready >= 0) { goPlot(ready); out.push(it); continue; }
+        const thirsty = pickPlot((x) => growing(x) && x.life < 0.5);
+        if (thirsty >= 0) { claimed.add(thirsty); go(station("water").x, station("water").y); out.push(it); continue; }
+        const dead = pickPlot((x) => x.stage === S.DIED);
+        if (dead >= 0) { claimed.add(dead); go(station("tool").x, station("tool").y); out.push(it); continue; }
+
+        // Build supply for the most urgent under-supplied order.
+        const supply = (name) => g.plots.filter((x) => (growing(x) || x.stage === S.READY) && x.plant && x.plant.name === name).length;
+        const unmet = g.orders.filter((o) => o.need > supply(o.plant.name)).sort((a, b) => a.timeLeft - b.timeLeft)[0];
+        const treated = pickPlot((x) => x.stage === S.TREATED);
+        const virgin = pickPlot((x) => x.stage === S.VIRGIN);
+        if (unmet) {
+          if (treated >= 0) { claimed.add(treated); s.wantSeed = OG.PLANTS.findIndex((q) => q.name === unmet.plant.name); go(station("seed").x, station("seed").y); out.push(it); continue; }
+          if (virgin >= 0) { claimed.add(virgin); go(station("tool").x, station("tool").y); out.push(it); continue; }
+        }
+        if (treated >= 0) { claimed.add(treated); s.wantSeed = 0; go(station("seed").x, station("seed").y); out.push(it); continue; }
+        if (virgin >= 0) { claimed.add(virgin); go(station("tool").x, station("tool").y); out.push(it); continue; }
+
+        out.push(it); // idle
+      }
+      return out;
+    },
+  };
+})();

--- a/tests/e2e/coop.mjs
+++ b/tests/e2e/coop.mjs
@@ -1,0 +1,129 @@
+// Co-op balancing harness.
+//
+// Drives N bot players across player counts 1..4 and reports team score, star
+// distribution and load (expired orders, deaths, idle) per count — so the COOP
+// scaling in game.js (spawn rate, concurrent orders, star goals) can be tuned
+// against real multi-player throughput.
+//
+// Usage: node tests/e2e/coop.mjs [--difficulty 1] [--seeds 1,2,3,4,5]
+//        [--counts 1,2,3,4] [--out DIR]
+import { chromium } from "playwright";
+import http from "node:http";
+import { readFile, mkdir, writeFile, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = path.resolve(HERE, "../../web");
+
+const argv = process.argv.slice(2);
+const getArg = (n, d) => { const i = argv.indexOf(n); return i >= 0 && argv[i + 1] ? argv[i + 1] : d; };
+const DIFFICULTY = parseInt(getArg("--difficulty", "1"), 10);
+const SEEDS = getArg("--seeds", "1,2,3,4,5").split(",").map((s) => parseInt(s, 10));
+const COUNTS = getArg("--counts", "1,2,3,4").split(",").map((s) => parseInt(s, 10));
+const OUT = path.resolve(process.cwd(), getArg("--out", "tests/e2e/out/coop"));
+
+const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".json": "application/json", ".png": "image/png", ".wav": "audio/wav", ".mp3": "audio/mpeg" };
+function startServer() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = decodeURIComponent(req.url.split("?")[0]);
+      const file = path.join(WEB_DIR, path.normalize(url === "/" ? "/index.html" : url));
+      if (!file.startsWith(WEB_DIR)) return void res.writeHead(403).end();
+      const body = await readFile(file);
+      res.writeHead(200, { "Content-Type": MIME[path.extname(file)] || "application/octet-stream" });
+      res.end(body);
+    } catch { res.writeHead(404).end("not found"); }
+  });
+  return new Promise((r) => server.listen(0, "127.0.0.1", () => r(server)));
+}
+
+const mean = (a) => a.reduce((x, y) => x + y, 0) / a.length;
+
+async function main() {
+  await rm(OUT, { recursive: true, force: true });
+  await mkdir(OUT, { recursive: true });
+
+  const server = await startServer();
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const browser = await chromium.launch({ args: ["--no-sandbox"] });
+  const page = await browser.newPage();
+  await page.goto(`${base}/index.html?debug`);
+  await page.waitForFunction(() => window.__OG__ && window.__OG__.assetsReady(), null, { timeout: 30000 });
+  await page.addScriptTag({ path: path.join(HERE, "coop-bot.js") });
+
+  const coopConst = await page.evaluate(() => window.__OG__.COOP);
+  console.log(`Co-op balancing — dificuldade ${DIFFICULTY}, seeds ${SEEDS.join(",")}\nCOOP atual: ${JSON.stringify(coopConst)}\n`);
+
+  const rows = [];
+  for (const count of COUNTS) {
+    const runs = [];
+    for (const seed of SEEDS) {
+      const m = await page.evaluate(({ count, difficulty, seed }) => {
+        const OG = window.__OG__, BOT = window.__OG_COOPBOT__;
+        OG.startHeadlessCoop({ count, difficulty, seed }); BOT.reset();
+        const dt = 1 / 30; let deaths = 0, idle = 0, ticks = 0, guard = 20000;
+        const prev = OG.game.plots.map((p) => p.stage);
+        while (OG.gameState === "playing" && OG.game.time > 0 && guard-- > 0) {
+          OG.setBotIntents(BOT.intents(OG));
+          OG.tick(dt, false);
+          if (OG.gameState !== "playing") break;
+          const g = OG.game;
+          for (let k = 0; k < g.plots.length; k++) {
+            if (prev[k] !== OG.STAGE.DIED && g.plots[k].stage === OG.STAGE.DIED) deaths++;
+            prev[k] = g.plots[k].stage;
+          }
+          ticks++;
+          let mv = 0; for (const p of g.players) if (p.moving) mv++;
+          idle += (g.players.length - mv) / g.players.length;
+        }
+        const g = OG.game, goals = OG.starGoals(), s = g.score;
+        const stars = s >= goals[2] ? 3 : s >= goals[1] ? 2 : s >= goals[0] ? 1 : 0;
+        return { score: s, stars, goals, delivered: g.stats.delivered, expired: g.stats.expired, spawned: g.orderId - 1, deaths, idlePct: +(100 * idle / Math.max(1, ticks)).toFixed(1) };
+      }, { count, difficulty: DIFFICULTY, seed });
+      runs.push(m);
+    }
+    const agg = {
+      count,
+      goals: runs[0].goals,
+      meanScore: Math.round(mean(runs.map((r) => r.score))),
+      maxScore: Math.max(...runs.map((r) => r.score)),
+      avgStars: +mean(runs.map((r) => r.stars)).toFixed(2),
+      delivered: +mean(runs.map((r) => r.delivered)).toFixed(1),
+      expired: +mean(runs.map((r) => r.expired)).toFixed(1),
+      spawned: +mean(runs.map((r) => r.spawned)).toFixed(1),
+      deaths: +mean(runs.map((r) => r.deaths)).toFixed(1),
+      idlePct: +mean(runs.map((r) => r.idlePct)).toFixed(1),
+    };
+    rows.push(agg);
+    console.log(`${count}p -> score=${agg.meanScore} (max ${agg.maxScore}) stars=${agg.avgStars} goals=${agg.goals.join("/")} deliv=${agg.delivered} exp=${agg.expired}/${agg.spawned} deaths=${agg.deaths} idle=${agg.idlePct}%`);
+  }
+
+  await browser.close();
+  server.close();
+
+  // Suggested starScale so each count keeps the SAME difficulty feel relative to
+  // its achievable ceiling as solo (starScale[N] = ceiling_N / ceiling_1).
+  const ceil1 = rows.find((r) => r.count === 1)?.maxScore || rows[0].maxScore;
+  const md = [];
+  md.push(`# Co-op balancing — dificuldade ${DIFFICULTY} (${SEEDS.length} seeds/contagem)`);
+  md.push("");
+  md.push(`COOP avaliado: \`${JSON.stringify(coopConst)}\``);
+  md.push("");
+  md.push(`| jogadores | score méd | max | ★ méd | metas | entreg | perdidos/gerados | mortas | parado% | starScale sugerido |`);
+  md.push(`| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |`);
+  for (const r of rows) {
+    const sugg = +(r.maxScore / ceil1).toFixed(2);
+    md.push(`| ${r.count} | ${r.meanScore} | ${r.maxScore} | ${r.avgStars} | ${r.goals.join("/")} | ${r.delivered} | ${r.expired}/${r.spawned} | ${r.deaths} | ${r.idlePct} | ${sugg} |`);
+  }
+  md.push("");
+  md.push(`**Leitura:** \`starScale\` sugerido = teto_N / teto_solo (mantém o mesmo feel relativo).`);
+  md.push(`Muitos **perdidos** ⇒ baixar \`spawnScale\`/subir \`concurrentBonus\` cedo demais; **idle alto** ⇒ pode acelerar spawn.`);
+
+  await writeFile(path.join(OUT, "coop.json"), JSON.stringify({ difficulty: DIFFICULTY, seeds: SEEDS, coop: coopConst, rows, suggestedStarScale: rows.map((r) => +(r.maxScore / ceil1).toFixed(2)) }, null, 2));
+  await writeFile(path.join(OUT, "coop.md"), md.join("\n"));
+  console.log(`\nSuggested starScale (teto_N/teto_solo): [${rows.map((r) => +(r.maxScore / ceil1).toFixed(2)).join(", ")}]`);
+  console.log(`Wrote ${OUT}`);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/web/game.js
+++ b/web/game.js
@@ -23,7 +23,9 @@ const DIFFICULTY_MULT = [4, 3, 2, 1];
 const COOP = {
   spawnScale: [1, 0.72, 0.58, 0.5],
   concurrentBonus: [0, 2, 3, 4],
-  starScale: [1, 1.8, 2.5, 3.2],
+  // Star goals scale ~with measured team throughput (sublinear: shared plots +
+  // one well). Ratios from the co-op harness (teto_N / teto_solo). See tests/e2e/.
+  starScale: [1, 1.8, 2.1, 2.6],
 };
 const PLAYER_COLORS = ["#ffd24a", "#4ea8ff", "#ff6b6b", "#74e36b"];
 const PLAYER_SPAWN = [[0, 30], [-70, 30], [70, 30], [0, 96]];
@@ -254,7 +256,11 @@ function gatherIntents() {
   for (let i = 0; i < game.players.length; i++) {
     const dev = game.players[i].device;
     let it;
-    if (dev.type === "gamepad") {
+    if (dev.type === "bot") {
+      // Headless co-op: intents injected by the balancing harness.
+      it = (game._botIntents && game._botIntents[i]) ||
+        { mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false };
+    } else if (dev.type === "gamepad") {
       it = gamepadIntent(dev.index) || { mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false };
     } else {
       const km = dev.keymap;
@@ -1295,7 +1301,8 @@ if (location.search.includes("debug")) {
     get gameState() { return gameState; },
     get PLANTS() { return PLANTS; },
     // Constants exposed so the harness reports against live tuning values.
-    TUNE, ROUND, ORDER, WORLD, HOLD, STAGE,
+    TUNE, ROUND, ORDER, WORLD, HOLD, STAGE, COOP,
+    starGoals,
     // Raw input maps so an external bot can drive via the same input path the
     // human uses (movement runs at real game speed — realistic for balancing).
     keys, justPressed,
@@ -1323,6 +1330,23 @@ if (location.search.includes("debug")) {
       resultScreen.classList.add("hidden");
       return true;
     },
+    // Headless co-op: N bot-driven slots. The balancing harness injects one
+    // intent per player each tick via setBotIntents before calling tick().
+    startHeadlessCoop({ count = 2, difficulty = 1, seed = null } = {}) {
+      if (seed != null) seedRng(seed);
+      selectedPlayers = count; selectedDifficulty = difficulty;
+      sound.setMuted(true);
+      game = createGame(count, difficulty);
+      for (const p of game.players) p.device = { type: "bot" };
+      game._botIntents = [];
+      gameState = "playing";
+      running = false;
+      startScreen.classList.add("hidden");
+      pauseScreen.classList.add("hidden");
+      resultScreen.classList.add("hidden");
+      return true;
+    },
+    setBotIntents(arr) { game._botIntents = arr; },
     // One deterministic frame. Mirrors loop() but with a caller-supplied dt and
     // optional rendering (skip it for fast data-only runs).
     tick(dt, doRender = false) {


### PR DESCRIPTION
## O que é

Balanceamento do **co-op** com dados: um harness multi-bot que dirige N jogadores e mede o throughput de time, usado pra calibrar a escala `COOP` em `game.js`.

## Como

- **Caminho headless de co-op** novo em `game.js` (`startHeadlessCoop` + `setBotIntents` + device `"bot"`), **separado** do harness solo — o e2e por-PR fica intacto.
- **`coop-bot.js`**: bot intent-based que dirige N slots e **divide trabalho** (claims de canteiro pra não empilharem no mesmo crop).
- **`coop.mjs`** (`npm run coop`): roda contagens 1–4 × seeds e reporta score, distribuição de estrelas e carga (perdidos, mortes, idle) por contagem.

## 📊 Achado e ajuste

O throughput de time escala **sublinearmente** (canteiros e poço compartilhados): o bot de time faz ~2.6× a produção solo no 4p, **não 4×**.

| jogadores | score méd | teto | razão teto_N/teto_solo |
|---|---|---|---|
| 1 | 699 | 897 | 1.0 |
| 2 | 1371 | 1626 | 1.81 |
| 3 | 1571 | 1850 | 2.06 |
| 4 | 1947 | 2331 | 2.60 |

As metas antigas (`starScale [1, 1.8, 2.5, 3.2]`) **penalizavam 3p/4p**. Ajustado para **`[1, 1.8, 2.1, 2.6]`** (razões medidas), o que mantém o mesmo "feel" de dificuldade em todas as contagens. Expiração estável ~18%.

Metas resultantes: 2p `162/360/684` · 3p `189/420/798` · 4p `234/520/988`.

> O co-op bot é um proxy **mais forte** que o bot solo, então é usado só pras **razões relativas** de throughput, não pras metas absolutas (essas seguem calibradas pro jogador mediano, como no solo).

## Verificação

`npm run coop` (Fácil, 5 seeds/contagem) — tabela acima. Solo e e2e por-PR inalterados.

## Follow-up

- Idle sobe a ~30% no 4p (co-op meio ocioso em contagens altas) — dá pra acelerar `spawnScale`/subir `concurrentBonus` no 3p/4p numa próxima iteração (cascateia no `starScale`, então deixei fora deste PR).

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_