### PR TITLE
Co-op online: servidor WebSocket autoritativo (O-0→O-3)

### DIFF
--- a/.github/workflows/e2e-evidence.yml
+++ b/.github/workflows/e2e-evidence.yml
@@ -43,6 +43,9 @@ jobs:
           node tests/e2e/run.mjs --players 1 --seeds 1,2,3,4,5 --out tests/e2e/out/facil
           node tests/e2e/run.mjs --players 4 --seeds 1,2,3,4,5 --out tests/e2e/out/insano
 
+      - name: Online co-op integration test
+        run: node tests/net/online.mjs
+
       - name: Upload evidence
         uses: actions/upload-artifact@v4
         with:

--- a/docs/COOP_DESIGN.md
+++ b/docs/COOP_DESIGN.md
@@ -1,7 +1,17 @@
-# Co-op — Design (local 1–4 + gamepad, online depois)
+# Co-op — Design (local 1–4 + gamepad + online)
 
-> Status: **Fase 0+1+2 em implementação** (refactor de input + co-op local até 4 +
-> gamepad). Online (Fase 3) é **projetado aqui, construído depois**.
+> Status: **local (Fase 0–2) e online (O-0–O-3) implementados.** Servidor
+> WebSocket autoritativo em `server/`, núcleo de simulação compartilhado em
+> `web/sim.js`, cliente em `web/net.js`. Ver `server/README.md`.
+
+## Online — como ficou (WebSocket autoritativo)
+
+- **`web/sim.js`** — núcleo puro (sem DOM/áudio/canvas), roda igual no browser e no Node.
+- **`server/server.mjs`** — salas, cada uma com 1 estado autoritativo, passo fixo 30Hz a partir dos intents; snapshots ~15Hz. Host-agnóstico (portável p/ Fly/Render/Railway/Cloudflare DO).
+- **`web/net.js`** — envia o intent do dispositivo local por frame, **interpola** snapshots (delay ~120ms) e reconstrói um estado que o `render()` desenha sem mudança.
+- **Drop-in / reconexão:** como o servidor é a autoridade, host sair não encerra; jogador reentra num slot livre no meio do round.
+- **Lobby:** criar sala → código de 4 letras; entrar pelo código (celular via touch).
+- Teste de integração: `npm run test:net` (e no CI).
 
 ## Ideia-âncora
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,7 +50,7 @@ sozinho ou em co-op, com caos crescente.
 **Engenharia**
 - [ ] Níveis **data-driven** (JSON: estações, canteiros, pedidos, meta, tempo).
 - [ ] **Colisão real** com estações/obstáculos.
-- [ ] Tick determinístico + separação de sistemas (prep p/ co-op/replay).
+- [x] Tick determinístico + separação de sistemas — núcleo puro `web/sim.js` (sim ≠ render/IO), compartilhado browser/servidor.
 - [x] **CI no PR**: harness e2e (bot autoplayer headless) que gera evidência visual + dados de balanceamento por seed (`tests/e2e/`).
 - [ ] Pipeline de assets (poço/água animados, decorações, tilemap da cena Unity).
 
@@ -67,7 +67,7 @@ sozinho ou em co-op, com caos crescente.
 - [ ] Acessibilidade (remapeamento, daltonismo, modo assistido) + localização (PT/EN/ES).
 
 **Jogabilidade**
-- [ ] **Co-op online** (netcode) — avaliar custo/benefício vs. local.
+- [x] **Co-op online** (netcode) — servidor WebSocket autoritativo + interpolação + drop-in/reconexão (`server/`, `web/net.js`; ver `docs/COOP_DESIGN.md`).
 - [ ] Loja entre fases (upgrades de estação) e economia.
 - [ ] Chefes/eventos de fim de fase; fases temáticas (estações do ano, clima).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "overgarden-web",
       "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
       "devDependencies": {
         "playwright": "^1.49.0"
       }
@@ -56,6 +59,27 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "sweep": "node tests/e2e/sweep.mjs",
     "sweep:prod": "node tests/e2e/sweep.mjs --mode production",
     "sweep:insane": "node tests/e2e/sweep.mjs --players 4",
-    "coop": "node tests/e2e/coop.mjs"
+    "coop": "node tests/e2e/coop.mjs",
+    "server": "node server/server.mjs"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "playwright": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "sweep:prod": "node tests/e2e/sweep.mjs --mode production",
     "sweep:insane": "node tests/e2e/sweep.mjs --players 4",
     "coop": "node tests/e2e/coop.mjs",
-    "server": "node server/server.mjs"
+    "server": "node server/server.mjs",
+    "test:net": "node tests/net/online.mjs"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,46 @@
+# Overgarden — co-op server
+
+Authoritative WebSocket server for online co-op. Each room holds one
+authoritative `Sim` state (from `web/sim.js`), stepped at a fixed tick from the
+intents clients send; snapshots are broadcast back. Because the **server** is
+authoritative, a host leaving doesn't end the game, and players can drop in /
+reconnect into a freed slot mid-round.
+
+## Run locally
+
+```bash
+npm install
+npm run server          # ws://0.0.0.0:8787  (PORT env to change)
+```
+
+Then open the web build pointing the client at it:
+
+- Same machine/dev: the client defaults to `ws(s)://<page-host>:8787`.
+- Explicit: add `?server=ws://HOST:PORT` to the page URL.
+
+## Protocol (JSON over WebSocket)
+
+- **C→S:** `{t:"create",count,difficulty}` · `{t:"join",room}` · `{t:"setup",count,difficulty}` (host) · `{t:"start"}` (host) · `{t:"intent",intent}` · `{t:"leave"}`
+- **S→C:** `{t:"joined",room,slot,count,difficulty,host,started}` · `{t:"lobby",...}` · `{t:"snapshot",seq,s}` · `{t:"ended",result}` · `{t:"error",msg}` · `{t:"peer",left}`
+
+Edge inputs (interact/drop/confirm/menu) fire once: the server clears them after
+applying, so a single press isn't repeated across ticks.
+
+## Deploy (portable)
+
+It's a plain Node + `ws` process, so any host that runs a long-lived Node
+service works (Fly.io, Render, Railway, a VM…). Expose the port (default 8787)
+over `wss://` behind TLS and set the client's `?server=` (or bake a default).
+A single small instance handles many rooms. The room logic is host-agnostic, so
+it can later be ported to e.g. Cloudflare Workers + Durable Objects without
+touching the simulation.
+
+```bash
+PORT=8787 node server/server.mjs
+```
+
+## Test
+
+```bash
+npm run test:net        # boots server + 2 headless clients, asserts sync/drop-in
+```

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -99,11 +99,10 @@ wss.on("connection", (ws) => {
     } else if (m.t === "join") {
       const r = rooms.get((m.room || "").toUpperCase());
       if (!r) return send(ws, { t: "error", msg: "Sala não encontrada" });
-      if (r.started) return send(ws, { t: "error", msg: "Partida já começou" });
-      const slot = freeSlot(r);
+      const slot = freeSlot(r); // mid-game join allowed (drop-in / reconnect)
       if (slot < 0) return send(ws, { t: "error", msg: "Sala cheia" });
       r.clients.set(slot, ws); ws._room = r.room; ws._slot = slot;
-      send(ws, { t: "joined", room: r.room, slot, count: r.count, difficulty: r.difficulty, host: false });
+      send(ws, { t: "joined", room: r.room, slot, count: r.count, difficulty: r.difficulty, host: false, started: r.started });
       lobby(r);
     } else if (m.t === "setup") {
       const r = rooms.get(ws._room);

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -1,0 +1,125 @@
+// Overgarden — authoritative co-op server.
+//
+// Rooms each hold one authoritative Sim state, stepped at a fixed tick from the
+// intents clients send. Snapshots are broadcast to all clients, which render
+// them. Portable: a plain Node + `ws` process (Fly/Render/Railway); the room
+// logic is host-agnostic so it can be ported to e.g. Cloudflare DO later.
+//
+// Protocol (JSON):
+//   C->S: {t:"create",count,difficulty} {t:"join",room} {t:"start"}
+//         {t:"intent",intent} {t:"setup",count,difficulty} {t:"leave"}
+//   S->C: {t:"joined",room,slot,count,difficulty,host} {t:"lobby",...}
+//         {t:"snapshot",seq,s} {t:"ended",result} {t:"error",msg} {t:"peer",...}
+import { WebSocketServer } from "ws";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import * as Sim from "../web/sim.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PORT = parseInt(process.env.PORT || "8787", 10);
+const TICK_HZ = 30, DT = 1 / TICK_HZ, BROADCAST_EVERY = 2; // ~15Hz snapshots
+
+// Plant data (name+rarity drive gameplay; sprite fields ride along, unused here).
+const atlas = JSON.parse(await readFile(path.resolve(HERE, "../web/assets/atlas.json"), "utf8"));
+Sim.setPlants(Sim.buildPlants(atlas));
+
+const rooms = new Map();
+const code = () => { let c = ""; for (let i = 0; i < 4; i++) c += "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"[Math.floor(Math.random() * 32)]; return c; };
+
+function makeRoom(count, difficulty) {
+  let room;
+  do { room = code(); } while (rooms.has(room));
+  const r = { room, count: Math.max(1, Math.min(4, count)), difficulty: Math.max(1, Math.min(4, difficulty)), clients: new Map(), intents: {}, state: null, started: false, seq: 0, tickN: 0, timer: null };
+  rooms.set(room, r);
+  return r;
+}
+
+const send = (ws, msg) => { if (ws.readyState === 1) ws.send(JSON.stringify(msg)); };
+function broadcast(r, msg) { for (const ws of r.clients.values()) send(ws, msg); }
+
+function freeSlot(r) { for (let i = 0; i < r.count; i++) if (!r.clients.has(i)) return i; return -1; }
+
+function lobby(r) {
+  broadcast(r, { t: "lobby", room: r.room, count: r.count, difficulty: r.difficulty, started: r.started, slots: [...r.clients.keys()].sort() });
+}
+
+// Serialize the minimal state clients need to render (plants by name).
+function serialize(st) {
+  return {
+    time: st.time, score: st.score, combo: st.combo, over: st.over, result: st.result,
+    goals: Sim.starGoals(st), playerCount: st.playerCount,
+    players: st.players.map((p) => ({ index: p.index, color: p.color, x: Math.round(p.x * 10) / 10, y: Math.round(p.y * 10) / 10, facing: p.facing, moving: p.moving, holding: p.holding, heldSeed: p.heldSeed ? p.heldSeed.name : null, heldPlant: p.heldPlant ? p.heldPlant.name : null, stamina: Math.round(p.stamina), anim: Math.round(p.anim * 100) / 100, seedMenu: { open: p.seedMenu.open, index: p.seedMenu.index } })),
+    plots: st.plots.map((pl) => ({ x: pl.x, y: pl.y, stage: pl.stage, progress: Math.round(pl.progress * 1000) / 1000, life: Math.round(pl.life * 1000) / 1000, wilt: Math.round(pl.wilt * 100) / 100, plant: pl.plant ? pl.plant.name : null })),
+    orders: st.orders.map((o) => ({ id: o.id, need: o.need, qty: o.qty, timeLeft: Math.round(o.timeLeft * 100) / 100, maxTime: o.maxTime, plant: o.plant.name })),
+    events: st.events.slice(),
+  };
+}
+
+function startRoom(r) {
+  if (r.started) return;
+  r.state = Sim.createState({ playerCount: r.count, difficulty: r.difficulty, seed: (Math.random() * 1e9) | 0 });
+  r.started = true; r.tickN = 0;
+  lobby(r);
+  r.timer = setInterval(() => {
+    const st = r.state;
+    const intents = [];
+    for (let i = 0; i < r.count; i++) intents[i] = r.intents[i] || Sim.ZERO_INTENT();
+    Sim.step(st, intents, DT);
+    // Edges fire once: clear them after applying.
+    for (let i = 0; i < r.count; i++) { const it = r.intents[i]; if (it) { it.interact = it.drop = it.confirm = it.navL = it.navR = false; } }
+    r.tickN++;
+    if (r.tickN % BROADCAST_EVERY === 0 || st.over) {
+      broadcast(r, { t: "snapshot", seq: r.seq++, s: serialize(st) });
+      st.events.length = 0;
+    }
+    if (st.over) { clearInterval(r.timer); r.timer = null; broadcast(r, { t: "ended", result: st.result }); }
+  }, 1000 / TICK_HZ);
+}
+
+function leave(ws) {
+  const r = ws._room && rooms.get(ws._room);
+  if (!r) return;
+  r.clients.delete(ws._slot);
+  delete r.intents[ws._slot];
+  broadcast(r, { t: "peer", left: ws._slot });
+  if (r.clients.size === 0) { if (r.timer) clearInterval(r.timer); rooms.delete(r.room); }
+  else lobby(r);
+}
+
+const wss = new WebSocketServer({ port: PORT });
+wss.on("connection", (ws) => {
+  ws.on("message", (buf) => {
+    let m; try { m = JSON.parse(buf.toString()); } catch { return; }
+    if (m.t === "create") {
+      const r = makeRoom(m.count || 1, m.difficulty || 1);
+      r.clients.set(0, ws); ws._room = r.room; ws._slot = 0;
+      send(ws, { t: "joined", room: r.room, slot: 0, count: r.count, difficulty: r.difficulty, host: true });
+      lobby(r);
+    } else if (m.t === "join") {
+      const r = rooms.get((m.room || "").toUpperCase());
+      if (!r) return send(ws, { t: "error", msg: "Sala não encontrada" });
+      if (r.started) return send(ws, { t: "error", msg: "Partida já começou" });
+      const slot = freeSlot(r);
+      if (slot < 0) return send(ws, { t: "error", msg: "Sala cheia" });
+      r.clients.set(slot, ws); ws._room = r.room; ws._slot = slot;
+      send(ws, { t: "joined", room: r.room, slot, count: r.count, difficulty: r.difficulty, host: false });
+      lobby(r);
+    } else if (m.t === "setup") {
+      const r = rooms.get(ws._room);
+      if (r && ws._slot === 0 && !r.started) { if (m.count) r.count = Math.max(1, Math.min(4, m.count)); if (m.difficulty) r.difficulty = Math.max(1, Math.min(4, m.difficulty)); lobby(r); }
+    } else if (m.t === "start") {
+      const r = rooms.get(ws._room);
+      if (r && ws._slot === 0) startRoom(r);
+    } else if (m.t === "intent") {
+      const r = rooms.get(ws._room);
+      if (r && m.intent) r.intents[ws._slot] = m.intent;
+    } else if (m.t === "leave") {
+      leave(ws);
+    }
+  });
+  ws.on("close", () => leave(ws));
+  ws.on("error", () => {});
+});
+
+console.log(`Overgarden co-op server on ws://0.0.0.0:${PORT}`);

--- a/tests/net/online.mjs
+++ b/tests/net/online.mjs
@@ -1,0 +1,74 @@
+// Online co-op integration test: boots the authoritative server + serves the
+// web build, opens two headless clients, and asserts that create/join/start,
+// authoritative sync, server-side continuation after a disconnect, and mid-game
+// drop-in all work. Exits non-zero on failure (used by CI and `npm run test:net`).
+import { chromium } from "playwright";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.resolve(HERE, "../../web");
+const SERVER = path.resolve(HERE, "../../server/server.mjs");
+const PORT = 8821;
+
+const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".json": "application/json", ".png": "image/png", ".wav": "audio/wav", ".mp3": "audio/mpeg" };
+const fails = [];
+function check(name, ok) { console.log(`${ok ? "✓" : "✗"} ${name}`); if (!ok) fails.push(name); }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const httpSrv = http.createServer(async (q, s) => {
+  try { const u = decodeURIComponent(q.url.split("?")[0]); const f = path.join(WEB, u === "/" ? "/index.html" : u); const b = await readFile(f); s.writeHead(200, { "Content-Type": MIME[path.extname(f)] || "application/octet-stream" }); s.end(b); }
+  catch { s.writeHead(404).end(); }
+});
+await new Promise((r) => httpSrv.listen(0, "127.0.0.1", r));
+const httpBase = `http://127.0.0.1:${httpSrv.address().port}`;
+const gameSrv = spawn("node", [SERVER], { env: { ...process.env, PORT: String(PORT) }, stdio: "ignore" });
+await sleep(900);
+const wsUrl = `ws://127.0.0.1:${PORT}`;
+
+const browser = await chromium.launch({ args: ["--no-sandbox"] });
+try {
+  const A = await browser.newPage();
+  const B = await browser.newPage();
+  for (const p of [A, B]) { await p.goto(`${httpBase}/index.html?debug`); await p.waitForFunction(() => window.__OG__ && window.__OG__.assetsReady(), null, { timeout: 30000 }); }
+
+  const room = await A.evaluate(async (u) => { await window.__OG_NET__.connectCreate(u, 2, 1); await new Promise((r) => setTimeout(r, 150)); return window.__OG_NET__.state().room; }, wsUrl);
+  check("host creates room (4-char code)", typeof room === "string" && room.length === 4);
+
+  await B.evaluate(async (a) => window.__OG_NET__.connectJoin(a.u, a.room), { u: wsUrl, room });
+  await sleep(200);
+  check("guest joins room", await B.evaluate(() => window.__OG_NET__.state().room) === room);
+
+  await A.evaluate(() => window.__OG_NET__.start());
+  await A.waitForFunction(() => window.__OG_NET__.state().phase === "playing", null, { timeout: 8000 });
+  await B.waitForFunction(() => window.__OG_NET__.state().phase === "playing", null, { timeout: 8000 });
+  check("both clients enter play", true);
+
+  await A.keyboard.down("d"); await B.keyboard.down("ArrowLeft");
+  await sleep(700);
+  await A.keyboard.up("d"); await B.keyboard.up("ArrowLeft");
+  await sleep(300);
+  const pa = await A.evaluate(() => window.__OG_NET__.state().snapshot.players.map((p) => Math.round(p.x)));
+  const pb = await B.evaluate(() => window.__OG_NET__.state().snapshot.players.map((p) => Math.round(p.x)));
+  check("authoritative state identical on both clients", JSON.stringify(pa) === JSON.stringify(pb));
+  check("P0 moved right and P1 moved left", pa[0] > 490 && pa[1] < 470);
+
+  const t1 = await A.evaluate(() => window.__OG_NET__.state().snapshot.time);
+  await B.evaluate(() => window.__OG_NET__.Net.ws.close());
+  await sleep(1100);
+  const t2 = await A.evaluate(() => window.__OG_NET__.state().snapshot.time);
+  check("server keeps running after a client disconnects", t1 > t2);
+
+  await B.evaluate(async (a) => { window.__OG_NET__.Net.on.snapshot = () => {}; await window.__OG_NET__.connectJoin(a.u, a.room); }, { u: wsUrl, room });
+  await sleep(600);
+  const bs = await B.evaluate(() => window.__OG_NET__.state());
+  check("mid-game drop-in / reconnect works", bs.phase === "playing" && !!bs.snapshot);
+} finally {
+  await browser.close(); httpSrv.close(); gameSrv.kill();
+}
+
+if (fails.length) { console.error(`\n${fails.length} check(s) failed: ${fails.join(", ")}`); process.exit(1); }
+console.log("\nAll online checks passed.");

--- a/web/game.js
+++ b/web/game.js
@@ -1,90 +1,15 @@
 "use strict";
-
 /*
- * Overgarden — web reimplementation (HTML5 Canvas).
+ * Overgarden — browser layer: rendering, input (keyboard/gamepad/touch), audio
+ * and the menu/loop, on top of the pure simulation in sim.js.
  *
- * Milestone 1 ("loop Overcooked mínimo"): timed rounds with order tickets,
- * star results, reversible wilting (watering matters), combos and juice, on
- * top of the original art/audio and the faithful farming loop.
+ * The simulation (state + update) lives in sim.js so it runs identically here
+ * and on the authoritative co-op server. This file owns everything the sim
+ * doesn't: canvas drawing, the input->intent layer, audio, and the DOM screens.
  */
+import * as Sim from "./sim.js";
 
-// Holding item states (EventsManager.HoldingItem)
-const HOLD = { NOTHING: 0, SEED: 1, WATER: 2, TOOL: 3, PLANT: 4 };
-
-// Plant stages (StageScript.PlantStages, 1-indexed in original)
-const STAGE = { VIRGIN: 1, TREATED: 2, SMALL: 3, MEDIUM: 4, GREAT: 5, READY: 6, DIED: 7 };
-
-// Difficulty multiplier indexed by difficulty-1 (StageScript.DifficultyMultiplier)
-const DIFFICULTY_MULT = [4, 3, 2, 1];
-
-// Co-op scaling by playerCount-1: more players => faster orders, more can be
-// active at once, higher star goals. First-pass values — tune with the e2e
-// multi-player harness (see docs/COOP_DESIGN.md). Solo keeps factor 1.
-const COOP = {
-  spawnScale: [1, 0.72, 0.58, 0.5],
-  concurrentBonus: [0, 2, 3, 4],
-  // Star goals scale ~with measured team throughput (sublinear: shared plots +
-  // one well). Ratios from the co-op harness (teto_N / teto_solo). See tests/e2e/.
-  starScale: [1, 1.8, 2.1, 2.6],
-};
-const PLAYER_COLORS = ["#ffd24a", "#4ea8ff", "#ff6b6b", "#74e36b"];
-const PLAYER_SPAWN = [[0, 30], [-70, 30], [70, 30], [0, 96]];
-
-const WORLD = { w: 960, h: 600 };
-
-const TUNE = {
-  normalSpeed: 175,
-  runSpeed: 320,
-  maxStamina: 100,
-  runDrain: 48,
-  walkRegen: 14,
-  idleRegen: 26,
-  // Life runs out before a growth stage completes, so plants need watering.
-  growthBase: 1.1,   // * rarity * mult => seconds to complete a growth stage
-  lifeBase: 1.3,     // * rarity * mult => seconds of life (< growth => must water)
-  wiltGrace: 3.0,    // seconds a plant can wilt (life 0) before dying — reversible
-  decayRampMin: 0.6, // life-decay multiplier at round start (forgiving)
-  decayRampMax: 1.3, // ...and at round end (harsher)
-  interactRadius: 72,
-};
-
-const ROUND = {
-  duration: 150,          // seconds
-  // Calibrated to the achievable ceiling measured by the e2e bot at the shipped
-  // pacing: 1★ ≈ a median solo run, 3★ ≈ a strong one. See tests/e2e/.
-  stars: [90, 200, 380], // score thresholds for 1/2/3 stars
-};
-
-const ORDER = {
-  maxConcurrent: 4,
-  baseReward: 70,           // * rarity * qty
-  unitReward: 10,           // per produce deposited toward an order
-  expirePenalty: 60,
-  spawnStart: 8, spawnEnd: 4, // seconds between spawns (round start -> end)
-  timeBase: 22, timePerRarity: 9, // base seconds to fulfil an order
-  diffTime: [1.5, 1.2, 1.0, 0.8],  // order time scale by difficulty (easy -> insano)
-  diffSpawn: [1.3, 1.1, 0.95, 0.8],// spawn-interval scale (easy spawns slower)
-  comboWindow: 12,          // seconds before an idle combo resets
-};
-
-// Seedable RNG — only gameplay-affecting randomness (order stream) routes
-// through rng() so headless runs with ?seed=N are reproducible. Visual-only
-// randomness (particles) stays on Math.random and never affects metrics.
-let _seedRng = null;
-function rng() { return _seedRng ? _seedRng() : Math.random(); }
-function seedRng(seed) {
-  // mulberry32 — tiny, deterministic PRNG.
-  let a = (seed >>> 0) || 1;
-  _seedRng = function () {
-    a |= 0; a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-// Built once assets load: PLANTS list sorted by rarity (SeedStallManager order).
-let PLANTS = [];
+const { HOLD, STAGE, WORLD, TUNE, ROUND, ORDER, COOP } = Sim;
 
 // ---------------------------------------------------------------------------
 // Canvas / DOM
@@ -111,7 +36,6 @@ function loadImage(name) {
     im.src = "assets/img/" + name;
   });
 }
-
 function loadAudio(name) {
   return new Promise((resolve) => {
     const a = new Audio("assets/audio/" + name);
@@ -120,28 +44,20 @@ function loadAudio(name) {
     a.load();
   });
 }
-
 async function loadAssets() {
   const atlas = await fetch("assets/atlas.json").then((r) => r.json());
   ASSETS.atlas = atlas;
-
   const sheets = new Set();
   for (const g of [atlas.character, atlas.items, atlas.plants, atlas.ui, atlas.tiles]) {
     for (const k in g) sheets.add(g[k].sheet);
   }
   await Promise.all([...sheets].map(async (s) => { ASSETS.img[s] = await loadImage(s); }));
-
-  await Promise.all(Object.entries(atlas.audio).map(async ([k, file]) => {
-    ASSETS.audio[k] = await loadAudio(file);
-  }));
-
-  PLANTS = Object.entries(atlas.plantData)
-    .map(([name, d]) => ({ name, rarity: d.rarity, main: d.main, stages: d.stages }))
-    .sort((a, b) => a.rarity - b.rarity || a.name.localeCompare(b.name));
+  await Promise.all(Object.entries(atlas.audio).map(async ([k, file]) => { ASSETS.audio[k] = await loadAudio(file); }));
+  Sim.setPlants(Sim.buildPlants(atlas));
 }
 
 // ---------------------------------------------------------------------------
-// Audio (sampled loops/one-shots + tiny synth cues for orders)
+// Audio
 // ---------------------------------------------------------------------------
 let actx = null;
 const sound = {
@@ -185,14 +101,22 @@ const sound = {
   },
 };
 
+// Drain the sim's event queue into audio one-shots.
+function playEvents() {
+  for (const e of game.events) {
+    if (e === "pickup") sound.pickup();
+    else if (e === "watering") sound.watering();
+    else if (e === "ding") sound.ding();
+    else if (e === "fail") sound.fail();
+  }
+  game.events.length = 0;
+}
+
 // ---------------------------------------------------------------------------
-// Input
+// Input (keyboard + gamepad + touch) -> per-player intents
 // ---------------------------------------------------------------------------
 const keys = {};
 const justPressed = {};
-// We index keys by BOTH e.key (e.g. "w", "shift", "arrowup") and e.code
-// (e.g. "shiftleft", "shiftright", "slash", "period", "enter") so a second
-// keyboard player can have distinct binds (left vs right shift, etc.).
 function setKey(name, down) {
   if (down) { if (!keys[name]) justPressed[name] = true; keys[name] = true; }
   else keys[name] = false;
@@ -211,9 +135,6 @@ function clearJustPressed() { for (const k in justPressed) justPressed[k] = fals
 
 const touchMove = { x: 0, y: 0, active: false };
 
-// Per-slot keyboard binds. Slot 0 in solo also accepts arrows (preserves the
-// original feel + the headless bot, which drives WASD). In co-op slot 0 is
-// WASD-only so the arrows belong to slot 1.
 function keymapForSlot(slot, playerCount) {
   if (slot === 0) {
     return playerCount === 1
@@ -223,10 +144,9 @@ function keymapForSlot(slot, playerCount) {
   if (slot === 1) {
     return { up: ["arrowup"], down: ["arrowdown"], left: ["arrowleft"], right: ["arrowright"], run: ["shiftright"], interact: ["slash", "enter"], drop: ["period"], navL: ["arrowleft"], navR: ["arrowright"], confirm: ["slash", "enter"] };
   }
-  return null; // slots 2+ are gamepad-only
+  return null;
 }
 
-// Gamepad previous-button state per pad index, for edge detection.
 const gpPrev = {};
 function gamepadIntent(gpIndex) {
   const pads = navigator.getGamepads ? navigator.getGamepads() : [];
@@ -242,54 +162,33 @@ function gamepadIntent(gpIndex) {
   const prev = gpPrev[gpIndex] || {};
   const edge = (k) => cur[k] && !prev[k];
   gpPrev[gpIndex] = cur;
-  if (edge("pause")) justPressed["p"] = true; // route gamepad Start to pause
-  return {
-    mx, my, run: cur.run,
-    interact: edge("interact"), drop: edge("drop"),
-    navL: edge("navL"), navR: edge("navR"), confirm: edge("interact"),
-  };
+  if (edge("pause")) justPressed["p"] = true;
+  return { mx, my, run: cur.run, interact: edge("interact"), drop: edge("drop"), navL: edge("navL"), navR: edge("navR"), confirm: edge("interact") };
 }
 
-// Build one intent per player slot for this frame. Slot 0 also folds in touch.
 function gatherIntents() {
   const out = [];
   for (let i = 0; i < game.players.length; i++) {
     const dev = game.players[i].device;
     let it;
     if (dev.type === "bot") {
-      // Headless co-op: intents injected by the balancing harness.
-      it = (game._botIntents && game._botIntents[i]) ||
-        { mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false };
+      it = (game._botIntents && game._botIntents[i]) || Sim.ZERO_INTENT();
+    } else if (dev.type === "remote") {
+      it = game._remoteIntents && game._remoteIntents[i] ? game._remoteIntents[i] : Sim.ZERO_INTENT();
     } else if (dev.type === "gamepad") {
-      it = gamepadIntent(dev.index) || { mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false };
+      it = gamepadIntent(dev.index) || Sim.ZERO_INTENT();
     } else {
       const km = dev.keymap;
       let mx = (anyDown(km.right) ? 1 : 0) - (anyDown(km.left) ? 1 : 0);
       let my = (anyDown(km.down) ? 1 : 0) - (anyDown(km.up) ? 1 : 0);
-      it = {
-        mx, my, run: anyDown(km.run),
-        interact: anyPressed(km.interact), drop: anyPressed(km.drop),
-        navL: anyPressed(km.navL), navR: anyPressed(km.navR), confirm: anyPressed(km.confirm),
-      };
-      // Touch (mobile, slot 0 only): analog joystick + on-screen buttons (which
-      // set the slot-0 keys via bindTouch).
-      if (i === 0 && touchMove.active && Math.hypot(touchMove.x, touchMove.y) > 0.22) {
-        it.mx = touchMove.x; it.my = touchMove.y;
-      }
+      it = { mx, my, run: anyDown(km.run), interact: anyPressed(km.interact), drop: anyPressed(km.drop), navL: anyPressed(km.navL), navR: anyPressed(km.navR), confirm: anyPressed(km.confirm) };
+      if (i === 0 && touchMove.active && Math.hypot(touchMove.x, touchMove.y) > 0.22) { it.mx = touchMove.x; it.my = touchMove.y; }
     }
     out.push(it);
   }
   return out;
 }
 
-// ---------------------------------------------------------------------------
-// Game state
-// ---------------------------------------------------------------------------
-let gameState = "menu"; // menu | playing | result
-let game = null;
-
-// Decide which input device drives each slot: keyboards first (0,1), then any
-// connected gamepads fill the rest.
 function assignDevices(playerCount) {
   const pads = navigator.getGamepads ? [...navigator.getGamepads()].filter(Boolean) : [];
   const devices = [];
@@ -298,417 +197,60 @@ function assignDevices(playerCount) {
     const km = keymapForSlot(slot, playerCount);
     if (km) devices.push({ type: "keyboard", keymap: km });
     else if (pads[padCursor]) devices.push({ type: "gamepad", index: pads[padCursor++].index });
-    else devices.push({ type: "keyboard", keymap: keymapForSlot(0, playerCount) }); // fallback
+    else devices.push({ type: "keyboard", keymap: keymapForSlot(0, playerCount) });
   }
   return devices;
 }
 
+// ---------------------------------------------------------------------------
+// Game state (the sim state) + thin wrapper
+// ---------------------------------------------------------------------------
+let gameState = "menu"; // menu | playing | result
+let game = null;
+let pendingSeed = null;
+let footActive = false;
+
 function createGame(playerCount, difficulty) {
-  playerCount = Math.max(1, Math.min(4, playerCount || 1));
-  difficulty = Math.max(1, Math.min(4, difficulty || 1));
-  const mult = DIFFICULTY_MULT[difficulty - 1];
-
-  const plots = [];
-  const cols = 3, rows = 2;
-  const startX = 300, startY = 215, gapX = 130, gapY = 150;
-  for (let r = 0; r < rows; r++) {
-    for (let c = 0; c < cols; c++) {
-      plots.push({
-        x: startX + c * gapX, y: startY + r * gapY,
-        stage: STAGE.VIRGIN, plant: null, progress: 0, life: 1, wilt: 0,
-      });
-    }
-  }
-
-  // Stations: top band kept clear for HUD/orders.
-  const stations = [
-    { type: "tool",  x: 92,  y: 250, label: "Ferramentas", icon: "shovel" },
-    { type: "seed",  x: 92,  y: 420, label: "Sementes",    icon: "seed" },
-    { type: "water", x: 868, y: 320, label: "Poço",        icon: "water" },
-    { type: "sales", x: 480, y: 548, label: "Entrega",     icon: "bag" },
-  ];
-
+  const s = Sim.createState({ playerCount, difficulty, seed: pendingSeed });
+  pendingSeed = null;
   const devices = assignDevices(playerCount);
-  const players = [];
-  for (let i = 0; i < playerCount; i++) {
-    const [ox, oy] = PLAYER_SPAWN[i];
-    players.push({
-      index: i, color: PLAYER_COLORS[i], device: devices[i],
-      x: WORLD.w / 2 + ox, y: WORLD.h / 2 + oy,
-      speed: 0, stamina: TUNE.maxStamina,
-      facing: "down", moving: false,
-      holding: HOLD.NOTHING, heldSeed: null, heldPlant: null,
-      anim: 0, navLatch: false,
-      seedMenu: { open: false, index: 0 },
-    });
+  s.players.forEach((p, i) => { p.device = devices[i]; });
+  s.player = s.players[0];          // back-compat aliases for the harness/debug
+  s.seedMenu = s.players[0].seedMenu;
+  return s;
+}
+
+// Advance one frame: gather intents, step the sim, then handle the audio/UI
+// side effects the sim deliberately doesn't.
+function stepGame(dt, doRender, withAudio) {
+  if (pressed("p") && gameState === "playing") togglePause();
+  if (gameState === "playing" && !game.paused) {
+    const intents = gatherIntents();
+    Sim.step(game, intents, dt);
+    if (withAudio) {
+      playEvents();
+      if (game.anyMoving && !footActive) { sound.footstepsOn(); footActive = true; }
+      else if (!game.anyMoving && footActive) { sound.footstepsOff(); footActive = false; }
+    } else { game.events.length = 0; }
+    if (game.over) finishRound();
   }
-
-  const g = {
-    mult, difficulty, playerCount,
-    score: 0, paused: false,
-    time: ROUND.duration,
-    orders: [], orderId: 1, orderSpawnTimer: 3,
-    combo: 0, comboTimer: 0,
-    stats: { delivered: 0, expired: 0 },
-    particles: [], floaters: [], shake: 0, anyMoving: false,
-    players, plots, stations,
-  };
-  // Back-compat aliases for the headless harness / debug API (single player).
-  g.player = players[0];
-  g.seedMenu = players[0].seedMenu;
-  return g;
+  if (doRender && game) render();
+  clearJustPressed();
 }
 
-function maxConcurrentOrders() { return ORDER.maxConcurrent + COOP.concurrentBonus[game.playerCount - 1]; }
-function starGoals() { const s = COOP.starScale[game.playerCount - 1]; return ROUND.stars.map((v) => Math.round(v * s)); }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-function dist(ax, ay, bx, by) { return Math.hypot(ax - bx, ay - by); }
-function lerp(a, b, t) { return a + (b - a) * t; }
-function clamp01(t) { return Math.max(0, Math.min(1, t)); }
-function roundProgress() { return clamp01(1 - game.time / ROUND.duration); }
-
-function nearestStation(p) {
-  let best = null, bestD = TUNE.interactRadius;
-  for (const s of game.stations) {
-    const d = dist(p.x, p.y, s.x, s.y);
-    if (d < bestD) { bestD = d; best = s; }
-  }
-  return best;
-}
-
-function nearestPlot(p) {
-  let best = null, bestD = TUNE.interactRadius;
-  for (const plot of game.plots) {
-    const d = dist(p.x, p.y, plot.x, plot.y);
-    if (d < bestD) { bestD = d; best = plot; }
-  }
-  return best;
-}
-
-function stationOf(type) { return game.stations.find((s) => s.type === type); }
-
-function growthTime(plot) { return TUNE.growthBase * plot.plant.rarity * game.mult; }
-function lifeTime(plot)   { return TUNE.lifeBase   * plot.plant.rarity * game.mult; }
-function decayMult()      { return lerp(TUNE.decayRampMin, TUNE.decayRampMax, roundProgress()); }
-
-// ---------------------------------------------------------------------------
-// Orders
-// ---------------------------------------------------------------------------
-function orderableRarity() {
-  const p = roundProgress();
-  if (p < 0.3) return 1;
-  if (p < 0.6) return 2;
-  return 3;
-}
-function orderInterval() {
-  return lerp(ORDER.spawnStart, ORDER.spawnEnd, roundProgress())
-    * ORDER.diffSpawn[game.difficulty - 1] * COOP.spawnScale[game.playerCount - 1];
-}
-function spawnOrder() {
-  if (game.orders.length >= maxConcurrentOrders()) return;
-  const maxR = orderableRarity();
-  const pool = PLANTS.filter((p) => p.rarity <= maxR);
-  const plant = pool[Math.floor(rng() * pool.length)];
-  const p = roundProgress();
-  let qty = 1;
-  if (p > 0.3 && rng() < 0.5) qty++;
-  if (p > 0.6 && rng() < 0.4) qty++;
-  const time = (ORDER.timeBase + ORDER.timePerRarity * plant.rarity) * ORDER.diffTime[game.difficulty - 1];
-  game.orders.push({ plant, need: qty, qty, timeLeft: time, maxTime: time, id: game.orderId++ });
-}
-
-function ordersNeeding(name) {
-  return game.orders.filter((o) => o.plant.name === name && o.need > 0);
-}
-
-function updateOrders(dt) {
-  game.orderSpawnTimer -= dt;
-  if (game.orderSpawnTimer <= 0) {
-    spawnOrder();
-    game.orderSpawnTimer = orderInterval();
-  }
-  for (const o of game.orders) o.timeLeft -= dt;
-  for (let i = game.orders.length - 1; i >= 0; i--) {
-    if (game.orders[i].timeLeft <= 0) {
-      game.orders.splice(i, 1);
-      game.score = Math.max(0, game.score - ORDER.expirePenalty);
-      game.combo = 0;
-      game.stats.expired++;
-      const st = stationOf("sales");
-      spawnParticles(st.x, st.y - 12, { n: 12, color: "#e74c3c", speed: 130 });
-      spawnFloater(st.x, st.y - 30, "-" + ORDER.expirePenalty, "#e74c3c");
-      addShake(8);
-      sound.fail();
-    }
-  }
-  if (game.comboTimer > 0) {
-    game.comboTimer -= dt;
-    if (game.comboTimer <= 0) game.combo = 0;
-  }
-}
-
-function deliverPlant(p) {
-  if (p.holding !== HOLD.PLANT || !p.heldPlant) return;
-  const st = stationOf("sales");
-  const matches = ordersNeeding(p.heldPlant.name);
-  if (matches.length === 0) {
-    spawnFloater(st.x, st.y - 28, "sem pedido!", "#e7a76a");
-    return; // forgiving: keep holding the produce
-  }
-  // Fulfil the most urgent matching order.
-  matches.sort((a, b) => a.timeLeft - b.timeLeft);
-  const o = matches[0];
-  o.need--;
-  game.score += ORDER.unitReward;
-  p.holding = HOLD.NOTHING; p.heldPlant = null;
-  spawnParticles(st.x, st.y - 12, { n: 6, color: "#9fe6ff", speed: 90 });
-  sound.pickup();
-  if (o.need <= 0) completeOrder(o);
-}
-
-function completeOrder(o) {
-  const base = ORDER.baseReward * o.plant.rarity * o.qty;
-  const tip = Math.round(base * 0.5 * (o.timeLeft / o.maxTime)); // faster = bigger tip
-  game.combo++;
-  game.comboTimer = ORDER.comboWindow;
-  const mult = 1 + 0.1 * Math.min(game.combo - 1, 9);
-  const total = Math.round((base + tip) * mult);
-  game.score += total;
-  game.stats.delivered++;
-  const st = stationOf("sales");
-  spawnParticles(st.x, st.y - 16, { n: 20, color: "#f7d774", speed: 150 });
-  spawnFloater(st.x, st.y - 34, "+" + total + (game.combo > 1 ? "  x" + game.combo : ""), "#f7d774");
-  addShake(7);
-  sound.ding();
-  const idx = game.orders.indexOf(o);
-  if (idx >= 0) game.orders.splice(idx, 1);
-}
-
-// ---------------------------------------------------------------------------
-// Interactions
-// ---------------------------------------------------------------------------
-function handleInteract(p, intent) {
-  if (intent.drop && p.holding !== HOLD.PLANT) { p.holding = HOLD.NOTHING; p.heldSeed = null; }
-  if (!intent.interact) return;
-
-  const station = nearestStation(p);
-  if (station) { interactStation(p, station); return; }
-  const plot = nearestPlot(p);
-  if (plot) interactPlot(p, plot);
-}
-
-function interactStation(p, s) {
-  switch (s.type) {
-    case "tool":
-      if (p.holding !== HOLD.PLANT) { p.holding = HOLD.TOOL; p.heldSeed = null; sound.pickup(); }
-      break;
-    case "water":
-      if (p.holding !== HOLD.PLANT) { p.holding = HOLD.WATER; p.heldSeed = null; sound.pickup(); }
-      break;
-    case "seed":
-      if (p.holding !== HOLD.PLANT) { p.seedMenu.open = true; }
-      break;
-    case "sales":
-      deliverPlant(p);
-      break;
-  }
-}
-
-function interactPlot(p, plot) {
-  if (plot.stage === STAGE.DIED) {
-    if (p.holding === HOLD.TOOL) { resetPlot(plot); p.holding = HOLD.NOTHING; sound.pickup(); }
-    return;
-  }
-  if (p.holding === HOLD.TOOL && plot.stage === STAGE.VIRGIN) {
-    plot.stage = STAGE.TREATED; plot.life = 1; p.holding = HOLD.NOTHING; sound.pickup();
-    spawnParticles(plot.x, plot.y, { n: 8, color: "#6b4a2b", speed: 70 });
-    return;
-  }
-  if (p.holding === HOLD.SEED && plot.stage === STAGE.TREATED && p.heldSeed) {
-    plot.plant = p.heldSeed; plot.stage = STAGE.SMALL; plot.progress = 0; plot.life = 1; plot.wilt = 0;
-    p.holding = HOLD.NOTHING; p.heldSeed = null; sound.pickup();
-    spawnParticles(plot.x, plot.y - 6, { n: 8, color: "#5fd35f", speed: 80 });
-    return;
-  }
-  const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
-  if (p.holding === HOLD.WATER && growing) {
-    plot.life = 1; plot.wilt = 0; p.holding = HOLD.NOTHING; sound.watering();
-    spawnParticles(plot.x, plot.y - 10, { n: 10, color: "#7ec8ff", speed: 110 });
-    return;
-  }
-  if (p.holding === HOLD.NOTHING && plot.stage === STAGE.READY) {
-    p.holding = HOLD.PLANT; p.heldPlant = plot.plant;
-    spawnParticles(plot.x, plot.y - 14, { n: 12, color: "#fff0a8", speed: 120 });
-    resetPlot(plot); sound.pickup();
-  }
-}
-
-function resetPlot(plot) {
-  plot.stage = STAGE.VIRGIN; plot.plant = null; plot.progress = 0; plot.life = 1; plot.wilt = 0;
-}
-
-function selectSeed(p) {
-  p.holding = HOLD.SEED; p.heldSeed = PLANTS[p.seedMenu.index];
-  p.seedMenu.open = false; sound.pickup();
-}
-
-// ---------------------------------------------------------------------------
-// FX (particles / floating text / screenshake)
-// ---------------------------------------------------------------------------
-function spawnParticles(x, y, { n = 8, color = "#fff", speed = 100, gravity = 220 } = {}) {
-  for (let i = 0; i < n; i++) {
-    const a = Math.random() * Math.PI * 2;
-    const sp = speed * (0.4 + Math.random() * 0.6);
-    game.particles.push({
-      x, y, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp - speed * 0.3,
-      life: 0.5 + Math.random() * 0.4, maxLife: 0.9, size: 2 + Math.random() * 3,
-      color, gravity,
-    });
-  }
-}
-function spawnFloater(x, y, text, color) {
-  game.floaters.push({ x, y, vy: -34, life: 1.2, maxLife: 1.2, text, color });
-}
-function addShake(a) { game.shake = Math.min(12, game.shake + a); }
-
-function updateFX(dt) {
-  for (let i = game.particles.length - 1; i >= 0; i--) {
-    const p = game.particles[i];
-    p.vy += p.gravity * dt;
-    p.x += p.vx * dt; p.y += p.vy * dt;
-    p.life -= dt;
-    if (p.life <= 0) game.particles.splice(i, 1);
-  }
-  for (let i = game.floaters.length - 1; i >= 0; i--) {
-    const f = game.floaters[i];
-    f.y += f.vy * dt; f.life -= dt;
-    if (f.life <= 0) game.floaters.splice(i, 1);
-  }
-  if (game.shake > 0) game.shake = Math.max(0, game.shake - 30 * dt);
-}
-
-// ---------------------------------------------------------------------------
-// Update
-// ---------------------------------------------------------------------------
-function update(dt) {
-  if (gameState !== "playing" || game.paused) return;
-
-  game.time -= dt;
-  if (game.time <= 0) { game.time = 0; endRound(); return; }
-
-  updateFX(dt);
-  updateOrders(dt);
-
-  const intents = gatherIntents();
-  let anyMoving = false;
-  for (let i = 0; i < game.players.length; i++) {
-    const p = game.players[i], intent = intents[i];
-    if (p.seedMenu.open) { updateSeedMenu(p, intent); p.moving = false; continue; }
-    updatePlayer(p, intent, dt);
-    handleInteract(p, intent);
-    if (p.moving) anyMoving = true;
-  }
-  updatePlots(dt);
-
-  // Footsteps loop on while anyone walks.
-  if (anyMoving && !game.anyMoving) sound.footstepsOn();
-  else if (!anyMoving && game.anyMoving) sound.footstepsOff();
-  game.anyMoving = anyMoving;
-}
-
-function updateSeedMenu(p, intent) {
-  if (intent.navL) p.seedMenu.index = Math.max(0, p.seedMenu.index - 1);
-  if (intent.navR) p.seedMenu.index = Math.min(PLANTS.length - 1, p.seedMenu.index + 1);
-  // Analog stick navigation with a per-player latch.
-  if (Math.abs(intent.mx) > 0.55 && !p.navLatch) {
-    p.seedMenu.index = Math.max(0, Math.min(PLANTS.length - 1, p.seedMenu.index + (intent.mx > 0 ? 1 : -1)));
-    p.navLatch = true;
-  } else if (Math.abs(intent.mx) < 0.3) {
-    p.navLatch = false;
-  }
-  if (intent.confirm) selectSeed(p);
-}
-
-function updatePlayer(p, intent, dt) {
-  let dx = intent.mx, dy = intent.my;
-  const inMag = Math.hypot(dx, dy);
-  const analogMag = inMag > 0 ? Math.min(1, inMag) : 1;
-
-  const wasMoving = p.moving;
-  p.moving = dx !== 0 || dy !== 0;
-
-  const running = intent.run && p.moving && p.stamina > 0;
-  if (running) {
-    p.speed = TUNE.runSpeed;
-    p.stamina -= TUNE.runDrain * dt;
-    if (p.stamina <= 0) { p.stamina = 0; p.speed = TUNE.normalSpeed; }
-  } else {
-    p.speed = TUNE.normalSpeed;
-    p.stamina += (p.moving ? TUNE.walkRegen : TUNE.idleRegen) * dt;
-  }
-  p.stamina = Math.max(0, Math.min(TUNE.maxStamina, p.stamina));
-
-  if (p.moving) {
-    const len = Math.hypot(dx, dy);
-    dx /= len; dy /= len;
-    if (Math.abs(dx) > Math.abs(dy)) p.facing = dx < 0 ? "left" : "right";
-    else p.facing = dy < 0 ? "up" : "down";
-    const sp = p.speed * analogMag;
-    p.x += dx * sp * dt;
-    p.y += dy * sp * dt;
-    p.anim += dt * (running ? 12 : 8);
-  } else {
-    p.anim += dt * 3;
-  }
-
-  p.x = Math.max(28, Math.min(WORLD.w - 28, p.x));
-  p.y = Math.max(132, Math.min(WORLD.h - 28, p.y));
-}
-
-function updatePlots(dt) {
-  const decay = decayMult();
-  for (const plot of game.plots) {
-    const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
-    if (growing) {
-      if (plot.life > 0) {
-        // healthy: grow + lose life
-        plot.progress += dt / growthTime(plot);
-        if (plot.progress >= 1) { plot.progress = 0; plot.stage++; plot.life = 1; plot.wilt = 0; }
-        plot.life -= (dt / lifeTime(plot)) * decay;
-        if (plot.life < 0) plot.life = 0;
-      } else {
-        // wilting: growth paused; dies if not watered within the grace window
-        plot.wilt += dt;
-        if (plot.wilt >= TUNE.wiltGrace) {
-          plot.stage = STAGE.DIED; plot.wilt = 0;
-          spawnParticles(plot.x, plot.y - 8, { n: 8, color: "#7a5230", speed: 70 });
-        }
-      }
-    } else if (plot.stage === STAGE.TREATED) {
-      plot.life -= dt / (TUNE.lifeBase * 3 * game.mult);
-      if (plot.life <= 0) resetPlot(plot);
-    }
-  }
-}
-
-function endRound() {
+function finishRound() {
   gameState = "result";
+  footActive = false;
   sound.footstepsOff();
   for (const k in ASSETS.audio) ASSETS.audio[k].pause();
   showTouchControls(false);
-
-  const s = game.score;
-  const goals = starGoals();
-  const stars = (s >= goals[2]) ? 3 : (s >= goals[1]) ? 2 : (s >= goals[0]) ? 1 : 0;
+  const r = game.result;
   document.getElementById("result-stars").innerHTML =
-    [0, 1, 2].map((i) => `<span class="${i < stars ? "on" : "off"}">★</span>`).join("");
-  document.getElementById("result-score").textContent = "Score: " + s;
+    [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
+  document.getElementById("result-score").textContent = "Score: " + r.score;
   document.getElementById("result-stats").textContent =
-    `Pedidos entregues: ${game.stats.delivered} · perdidos: ${game.stats.expired}` +
-    (stars < 3 ? ` · próxima estrela em ${goals[Math.min(stars, 2)]}` : " · máximo!");
+    `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}` +
+    (r.stars < 3 ? ` · próxima estrela em ${r.goals[Math.min(r.stars, 2)]}` : " · máximo!");
   resultScreen.classList.remove("hidden");
 }
 
@@ -734,7 +276,6 @@ function charFrame(p) {
   const idx = Math.floor(p.anim) % data.frames.length;
   return { sheet: data.sheet, rect: data.frames[idx] };
 }
-
 function drawTile(sheetKey, col, row, dx, dy, dw, dh) {
   const t = ASSETS.atlas.tiles[sheetKey];
   if (!t) return;
@@ -747,9 +288,7 @@ const TILE_PX = 48;
 // ---------------------------------------------------------------------------
 function render() {
   ctx.save();
-  if (game.shake > 0) {
-    ctx.translate((Math.random() - 0.5) * game.shake, (Math.random() - 0.5) * game.shake);
-  }
+  if (game.shake > 0) ctx.translate((Math.random() - 0.5) * game.shake, (Math.random() - 0.5) * game.shake);
   drawBackground();
   for (const plot of game.plots) drawPlot(plot);
   for (const s of game.stations) drawStation(s);
@@ -757,7 +296,6 @@ function render() {
   drawParticles();
   drawFloaters();
   ctx.restore();
-
   drawHUD();
   drawOrders();
   for (const p of game.players) drawInteractHint(p);
@@ -768,69 +306,46 @@ function drawBackground() {
   ctx.fillStyle = "#6ab04c";
   ctx.fillRect(0, 0, WORLD.w, WORLD.h);
   if (ASSETS.atlas.tiles.grass) {
-    for (let y = 0; y < WORLD.h; y += TILE_PX) {
-      for (let x = 0; x < WORLD.w; x += TILE_PX) drawTile("grass", 1, 3, x, y, TILE_PX, TILE_PX);
-    }
+    for (let y = 0; y < WORLD.h; y += TILE_PX) for (let x = 0; x < WORLD.w; x += TILE_PX) drawTile("grass", 1, 3, x, y, TILE_PX, TILE_PX);
   }
   drawFence();
 }
-
 function drawFence() {
   if (!ASSETS.atlas.tiles.fence) return;
   const F = 40;
-  for (let x = 0; x < WORLD.w; x += F) {
-    drawTile("fence", 1, 0, x, -4, F, F);
-    drawTile("fence", 1, 0, x, WORLD.h - F + 4, F, F);
-  }
-  for (let y = F - 8; y < WORLD.h - F; y += F) {
-    drawTile("fence", 1, 1, -4, y, F, F);
-    drawTile("fence", 1, 1, WORLD.w - F + 4, y, F, F);
-  }
+  for (let x = 0; x < WORLD.w; x += F) { drawTile("fence", 1, 0, x, -4, F, F); drawTile("fence", 1, 0, x, WORLD.h - F + 4, F, F); }
+  for (let y = F - 8; y < WORLD.h - F; y += F) { drawTile("fence", 1, 1, -4, y, F, F); drawTile("fence", 1, 1, WORLD.w - F + 4, y, F, F); }
 }
 
 function drawPlot(plot) {
   const size = 96;
   const x = plot.x - size / 2, y = plot.y - size / 2;
-
   if (plot.stage === STAGE.VIRGIN) {
     ctx.fillStyle = "rgba(255,255,255,0.07)";
     roundRect(x + 6, y + 6, size - 12, size - 12, 10, true, false);
-    ctx.strokeStyle = "rgba(60,45,25,0.35)"; ctx.lineWidth = 2;
-    ctx.setLineDash([6, 6]);
+    ctx.strokeStyle = "rgba(60,45,25,0.35)"; ctx.lineWidth = 2; ctx.setLineDash([6, 6]);
     roundRect(x + 6, y + 6, size - 12, size - 12, 10, false, true);
     ctx.setLineDash([]);
   } else if (ASSETS.atlas.tiles.soil) {
-    for (let r = 0; r < 3; r++) {
-      for (let c = 0; c < 3; c++) drawTile("soil", c, r + 2, x + c * 32, y + r * 32, 32, 32);
-    }
+    for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) drawTile("soil", c, r + 2, x + c * 32, y + r * 32, 32, 32);
   } else {
-    ctx.fillStyle = "#7a5230";
-    roundRect(x, y, size, size, 8, true, false);
+    ctx.fillStyle = "#7a5230"; roundRect(x, y, size, size, 8, true, false);
   }
-
   const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
   const wilting = growing && plot.life <= 0;
-
   if (plot.plant && plot.stage >= STAGE.SMALL) {
     const baseY = plot.y + size / 2 - 14;
     if (plot.stage === STAGE.DIED) {
       const r = plot.plant.stages[2] || plot.plant.stages[0];
-      ctx.globalAlpha = 0.45;
-      drawSpriteAnchored(r.sheet, r, plot.x, baseY, 58);
-      ctx.globalAlpha = 1;
-      ctx.fillStyle = "rgba(60,40,20,0.35)";
-      roundRect(x + 8, y + 8, size - 16, size - 16, 6, true, false);
+      ctx.globalAlpha = 0.45; drawSpriteAnchored(r.sheet, r, plot.x, baseY, 58); ctx.globalAlpha = 1;
+      ctx.fillStyle = "rgba(60,40,20,0.35)"; roundRect(x + 8, y + 8, size - 16, size - 16, 6, true, false);
     } else {
       const idx = Math.min(plot.stage - STAGE.SMALL, plot.plant.stages.length - 1);
       const r = plot.plant.stages[idx];
       const targetH = [40, 54, 66, 72][idx] || 60;
       if (wilting) {
-        // drooped + warm tint
-        ctx.globalAlpha = 0.8;
-        drawSpriteAnchored(r.sheet, r, plot.x, baseY + 4, targetH * 0.92);
-        ctx.globalAlpha = 1;
-        ctx.fillStyle = "rgba(180,90,30,0.22)";
-        roundRect(x + 8, y + 8, size - 16, size - 16, 6, true, false);
+        ctx.globalAlpha = 0.8; drawSpriteAnchored(r.sheet, r, plot.x, baseY + 4, targetH * 0.92); ctx.globalAlpha = 1;
+        ctx.fillStyle = "rgba(180,90,30,0.22)"; roundRect(x + 8, y + 8, size - 16, size - 16, 6, true, false);
       } else {
         drawSpriteAnchored(r.sheet, r, plot.x, baseY, targetH);
       }
@@ -840,18 +355,10 @@ function drawPlot(plot) {
       }
     }
   }
-
-  // Bars + "needs water" cue
   if (growing) {
     bar(x, y - 14, size, 5, plot.progress, "#7ec8ff", "#1f3a4d");
-    if (wilting) {
-      // urgent: shrinking red bar showing time left before death
-      bar(x, y - 7, size, 5, 1 - plot.wilt / TUNE.wiltGrace, "#e74c3c", "#3a1f1f");
-      drawWaterCue(plot, true);
-    } else {
-      bar(x, y - 7, size, 5, plot.life, lifeColor(plot.life), "#3a1f1f");
-      if (plot.life < 0.4) drawWaterCue(plot, false);
-    }
+    if (wilting) { bar(x, y - 7, size, 5, 1 - plot.wilt / TUNE.wiltGrace, "#e74c3c", "#3a1f1f"); drawWaterCue(plot, true); }
+    else { bar(x, y - 7, size, 5, plot.life, lifeColor(plot.life), "#3a1f1f"); if (plot.life < 0.4) drawWaterCue(plot, false); }
   } else if (plot.stage === STAGE.TREATED) {
     bar(x, y - 8, size, 5, plot.life, "#caa46a", "#3a2a1f");
   }
@@ -866,29 +373,16 @@ function drawWaterCue(plot, urgent) {
   drawFrame(item.sheet, { x: 0, y: 0, w: item.w, h: item.h }, plot.x - w / 2, plot.y - 52, w, h);
   ctx.globalAlpha = 1;
 }
-
-function lifeColor(t) {
-  if (t > 0.5) return "#5fd35f";
-  if (t > 0.25) return "#f0c419";
-  return "#e74c3c";
-}
+function lifeColor(t) { return t > 0.5 ? "#5fd35f" : t > 0.25 ? "#f0c419" : "#e74c3c"; }
 
 function drawStation(s) {
   const w = 84, h = 66;
   const x = s.x - w / 2, y = s.y - h / 2;
-  ctx.fillStyle = "#7a5230";
-  roundRect(x, y, w, h, 8, true, false);
-  ctx.fillStyle = "#5e3f24";
-  roundRect(x, y + h - 14, w, 14, 4, true, false);
-
+  ctx.fillStyle = "#7a5230"; roundRect(x, y, w, h, 8, true, false);
+  ctx.fillStyle = "#5e3f24"; roundRect(x, y + h - 14, w, 14, 4, true, false);
   const item = ASSETS.atlas.items[s.icon];
-  if (item) {
-    const ih = 40, iw = ih * (item.w / item.h);
-    drawFrame(item.sheet, { x: 0, y: 0, w: item.w, h: item.h }, s.x - iw / 2, s.y - ih / 2 - 4, iw, ih);
-  }
-  ctx.fillStyle = "#2a3a1f";
-  ctx.font = "bold 12px Trebuchet MS, sans-serif";
-  ctx.textAlign = "center";
+  if (item) { const ih = 40, iw = ih * (item.w / item.h); drawFrame(item.sheet, { x: 0, y: 0, w: item.w, h: item.h }, s.x - iw / 2, s.y - ih / 2 - 4, iw, ih); }
+  ctx.fillStyle = "#2a3a1f"; ctx.font = "bold 12px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
   ctx.fillText(s.label, s.x, y + h + 14);
 }
 
@@ -896,35 +390,21 @@ function drawPlayers() {
   const coop = game.playerCount > 1;
   const order = [...game.players].sort((a, b) => a.y - b.y);
   for (const p of order) {
-    // Shadow — tinted with the player colour in co-op to tell them apart.
     ctx.fillStyle = coop ? hexAlpha(p.color, 0.5) : "rgba(0,0,0,0.22)";
-    ctx.beginPath();
-    ctx.ellipse(p.x, p.y + 16, 18, 6, 0, 0, Math.PI * 2);
-    ctx.fill();
-    if (coop) {
-      ctx.strokeStyle = p.color; ctx.lineWidth = 2;
-      ctx.beginPath(); ctx.ellipse(p.x, p.y + 16, 19, 7, 0, 0, Math.PI * 2); ctx.stroke();
-    }
+    ctx.beginPath(); ctx.ellipse(p.x, p.y + 16, 18, 6, 0, 0, Math.PI * 2); ctx.fill();
+    if (coop) { ctx.strokeStyle = p.color; ctx.lineWidth = 2; ctx.beginPath(); ctx.ellipse(p.x, p.y + 16, 19, 7, 0, 0, Math.PI * 2); ctx.stroke(); }
     const f = charFrame(p);
     drawSpriteAnchored(f.sheet, f.rect, p.x, p.y + 18, 76);
     drawHeldIcon(p.x, p.y - 56, p);
     if (coop) {
-      // Player number tag + stamina pip under the feet.
-      ctx.fillStyle = p.color;
-      ctx.font = "bold 12px Trebuchet MS, sans-serif";
-      ctx.textAlign = "center";
+      ctx.fillStyle = p.color; ctx.font = "bold 12px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
       ctx.strokeStyle = "rgba(0,0,0,0.6)"; ctx.lineWidth = 3;
-      ctx.strokeText("P" + (p.index + 1), p.x, p.y - 64);
-      ctx.fillText("P" + (p.index + 1), p.x, p.y - 64);
+      ctx.strokeText("P" + (p.index + 1), p.x, p.y - 64); ctx.fillText("P" + (p.index + 1), p.x, p.y - 64);
       bar(p.x - 18, p.y + 24, 36, 4, p.stamina / TUNE.maxStamina, p.color, "#3a1f1f");
     }
   }
 }
-
-function hexAlpha(hex, a) {
-  const n = parseInt(hex.slice(1), 16);
-  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
-}
+function hexAlpha(hex, a) { const n = parseInt(hex.slice(1), 16); return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`; }
 
 function drawHeldIcon(cx, cy, p) {
   const items = ASSETS.atlas.items;
@@ -932,9 +412,7 @@ function drawHeldIcon(cx, cy, p) {
   if (p.holding === HOLD.TOOL) item = items.shovel;
   else if (p.holding === HOLD.WATER) item = items.water;
   else if (p.holding === HOLD.SEED) item = items.seed;
-  else if (p.holding === HOLD.PLANT && p.heldPlant && p.heldPlant.main) {
-    sheet = p.heldPlant.main.sheet; rect = p.heldPlant.main; h = 24;
-  }
+  else if (p.holding === HOLD.PLANT && p.heldPlant && p.heldPlant.main) { sheet = p.heldPlant.main.sheet; rect = p.heldPlant.main; h = 24; }
   if (item) { sheet = item.sheet; rect = { x: 0, y: 0, w: item.w, h: item.h }; }
   if (!sheet || !rect) return;
   const w = h * (rect.w / rect.h);
@@ -942,81 +420,49 @@ function drawHeldIcon(cx, cy, p) {
 }
 
 function drawParticles() {
-  for (const p of game.particles) {
-    ctx.globalAlpha = Math.max(0, p.life / p.maxLife);
-    ctx.fillStyle = p.color;
-    ctx.fillRect(p.x - p.size / 2, p.y - p.size / 2, p.size, p.size);
-  }
+  for (const p of game.particles) { ctx.globalAlpha = Math.max(0, p.life / p.maxLife); ctx.fillStyle = p.color; ctx.fillRect(p.x - p.size / 2, p.y - p.size / 2, p.size, p.size); }
   ctx.globalAlpha = 1;
 }
-
 function drawFloaters() {
   ctx.textAlign = "center";
   for (const f of game.floaters) {
     ctx.globalAlpha = Math.max(0, Math.min(1, f.life / 0.6));
     ctx.font = "bold 20px Trebuchet MS, sans-serif";
-    ctx.lineWidth = 3; ctx.strokeStyle = "rgba(0,0,0,0.6)";
-    ctx.strokeText(f.text, f.x, f.y);
-    ctx.fillStyle = f.color;
-    ctx.fillText(f.text, f.x, f.y);
+    ctx.lineWidth = 3; ctx.strokeStyle = "rgba(0,0,0,0.6)"; ctx.strokeText(f.text, f.x, f.y);
+    ctx.fillStyle = f.color; ctx.fillText(f.text, f.x, f.y);
   }
   ctx.globalAlpha = 1;
 }
 
-function fmtTime(t) {
-  const s = Math.max(0, Math.ceil(t));
-  return Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0");
-}
+function fmtTime(t) { const s = Math.max(0, Math.ceil(t)); return Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0"); }
 
 function drawHUD() {
-  // Score (top-left) + star goals
-  ctx.fillStyle = "rgba(20,30,16,0.75)";
-  roundRect(12, 10, 210, 44, 8, true, false);
-  ctx.fillStyle = "#f7d774";
-  ctx.font = "bold 22px Trebuchet MS, sans-serif";
-  ctx.textAlign = "left";
+  ctx.fillStyle = "rgba(20,30,16,0.75)"; roundRect(12, 10, 210, 44, 8, true, false);
+  ctx.fillStyle = "#f7d774"; ctx.font = "bold 22px Trebuchet MS, sans-serif"; ctx.textAlign = "left";
   ctx.fillText("Score " + game.score, 22, 33);
-  ctx.font = "12px Trebuchet MS, sans-serif";
-  ctx.fillStyle = "#b7d49a";
-  const goals = starGoals();
+  ctx.font = "12px Trebuchet MS, sans-serif"; ctx.fillStyle = "#b7d49a";
+  const goals = Sim.starGoals(game);
   const reached = goals.filter((t) => game.score >= t).length;
   ctx.fillText("★".repeat(reached) + "☆".repeat(3 - reached) + "  meta " + goals[2], 22, 48);
 
-  // Combo (under score, when active)
-  if (game.combo > 1) {
-    ctx.fillStyle = "#ffd24a";
-    ctx.font = "bold 16px Trebuchet MS, sans-serif";
-    ctx.fillText("COMBO x" + game.combo, 240, 32);
-  }
+  if (game.combo > 1) { ctx.fillStyle = "#ffd24a"; ctx.font = "bold 16px Trebuchet MS, sans-serif"; ctx.fillText("COMBO x" + game.combo, 240, 32); }
 
-  // Timer (top-center)
   const tw = 120, tx = WORLD.w / 2 - tw / 2;
-  ctx.fillStyle = "rgba(20,30,16,0.75)";
-  roundRect(tx, 8, tw, 38, 8, true, false);
-  ctx.fillStyle = game.time < 30 ? "#e74c3c" : "#fff";
-  ctx.font = "bold 24px Trebuchet MS, sans-serif";
-  ctx.textAlign = "center";
+  ctx.fillStyle = "rgba(20,30,16,0.75)"; roundRect(tx, 8, tw, 38, 8, true, false);
+  ctx.fillStyle = game.time < 30 ? "#e74c3c" : "#fff"; ctx.font = "bold 24px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
   ctx.fillText("⏱ " + fmtTime(game.time), WORLD.w / 2, 35);
 
-  // Stamina (top-right) — single player only; in co-op each player has a pip
-  // under their feet (drawn in drawPlayers).
   if (game.playerCount === 1) {
     const sx = WORLD.w - 232, sy = 14, sw = 220, sh = 16;
-    ctx.fillStyle = "rgba(20,30,16,0.75)";
-    roundRect(sx - 8, sy - 4, sw + 16, sh + 22, 8, true, false);
+    ctx.fillStyle = "rgba(20,30,16,0.75)"; roundRect(sx - 8, sy - 4, sw + 16, sh + 22, 8, true, false);
     ctx.fillStyle = "#3a1f1f"; roundRect(sx, sy, sw, sh, 5, true, false);
     ctx.fillStyle = "#5fd35f"; roundRect(sx, sy, sw * (game.players[0].stamina / TUNE.maxStamina), sh, 5, true, false);
     ctx.fillStyle = "#fff"; ctx.font = "11px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
     ctx.fillText("STAMINA", sx + sw / 2, sy + sh + 12);
-
-    // Held item label (bottom-left)
     const label = heldLabel(game.players[0]);
     if (label) {
-      ctx.fillStyle = "rgba(20,30,16,0.7)";
-      roundRect(12, WORLD.h - 44, 300, 32, 8, true, false);
-      ctx.fillStyle = "#e7e0cd";
-      ctx.font = "bold 15px Trebuchet MS, sans-serif";
-      ctx.textAlign = "left";
+      ctx.fillStyle = "rgba(20,30,16,0.7)"; roundRect(12, WORLD.h - 44, 300, 32, 8, true, false);
+      ctx.fillStyle = "#e7e0cd"; ctx.font = "bold 15px Trebuchet MS, sans-serif"; ctx.textAlign = "left";
       ctx.fillText("Segurando: " + label, 22, WORLD.h - 23);
     }
   }
@@ -1032,10 +478,8 @@ function drawOrders() {
   for (const o of game.orders) {
     const urg = o.timeLeft / o.maxTime;
     const col = urg > 0.5 ? "#5fd35f" : urg > 0.25 ? "#f0c419" : "#e74c3c";
-    ctx.fillStyle = "rgba(20,30,16,0.82)";
-    roundRect(x, y, cw, ch, 8, true, false);
-    ctx.strokeStyle = col; ctx.lineWidth = 3;
-    roundRect(x, y, cw, ch, 8, false, true);
+    ctx.fillStyle = "rgba(20,30,16,0.82)"; roundRect(x, y, cw, ch, 8, true, false);
+    ctx.strokeStyle = col; ctx.lineWidth = 3; roundRect(x, y, cw, ch, 8, false, true);
     const m = o.plant.main;
     if (m) { const ih = 32, iw = ih * (m.w / m.h); drawFrame(m.sheet, m, x + cw / 2 - iw / 2, y + 7, iw, ih); }
     ctx.fillStyle = "#fff"; ctx.font = "bold 14px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
@@ -1057,10 +501,9 @@ function heldLabel(p) {
 
 function drawInteractHint(p) {
   if (p.seedMenu.open) return;
-  const station = nearestStation(p);
-  const plot = !station ? nearestPlot(p) : null;
+  const station = Sim.nearestStation(game, p);
+  const plot = !station ? Sim.nearestPlot(game, p) : null;
   let hint = null;
-
   if (station) {
     if (station.type === "tool") hint = "E: pegar enxada";
     if (station.type === "water") hint = "E: pegar água";
@@ -1075,33 +518,22 @@ function drawInteractHint(p) {
     else if (plot.stage === STAGE.DIED && p.holding === HOLD.TOOL) hint = "E: limpar terra";
   }
   if (!hint) return;
-
-  ctx.font = "bold 16px Trebuchet MS, sans-serif";
-  ctx.textAlign = "center";
+  ctx.font = "bold 16px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
   const tw = ctx.measureText(hint).width;
-  ctx.fillStyle = "rgba(20,30,16,0.85)";
-  roundRect(p.x - tw / 2 - 10, p.y - 88, tw + 20, 24, 6, true, false);
-  ctx.fillStyle = "#f7d774";
-  ctx.fillText(hint, p.x, p.y - 71);
+  ctx.fillStyle = "rgba(20,30,16,0.85)"; roundRect(p.x - tw / 2 - 10, p.y - 88, tw + 20, 24, 6, true, false);
+  ctx.fillStyle = "#f7d774"; ctx.fillText(hint, p.x, p.y - 71);
 }
 
-// Compact, non-blocking seed picker floating above the player's head, so other
-// players keep playing while one chooses (Overcooked-style).
 function drawSeedMenu(p) {
+  const PLANTS = Sim.PLANTS;
   const idx = p.seedMenu.index;
-  const spacing = 58;
-  const panelW = 260, panelH = 96;
-  let cx = p.x;
-  cx = Math.max(panelW / 2 + 8, Math.min(WORLD.w - panelW / 2 - 8, cx));
+  const spacing = 58, panelW = 260, panelH = 96;
+  let cx = Math.max(panelW / 2 + 8, Math.min(WORLD.w - panelW / 2 - 8, p.x));
   let cy = p.y - 120;
-  if (cy < panelH + 10) cy = p.y + 130; // flip below if too high
+  if (cy < panelH + 10) cy = p.y + 130;
   const top = cy - panelH / 2;
-
-  ctx.fillStyle = "rgba(20,30,16,0.92)";
-  roundRect(cx - panelW / 2, top, panelW, panelH, 10, true, false);
-  ctx.strokeStyle = p.color; ctx.lineWidth = 3;
-  roundRect(cx - panelW / 2, top, panelW, panelH, 10, false, true);
-
+  ctx.fillStyle = "rgba(20,30,16,0.92)"; roundRect(cx - panelW / 2, top, panelW, panelH, 10, true, false);
+  ctx.strokeStyle = p.color; ctx.lineWidth = 3; roundRect(cx - panelW / 2, top, panelW, panelH, 10, false, true);
   const row = top + 38;
   for (let off = -2; off <= 2; off++) {
     const i = idx + off;
@@ -1113,16 +545,11 @@ function drawSeedMenu(p) {
     ctx.fillStyle = selected ? hexAlpha(p.color, 0.22) : "rgba(255,255,255,0.06)";
     ctx.beginPath(); ctx.arc(x, row, r, 0, Math.PI * 2); ctx.fill();
     if (selected) { ctx.strokeStyle = p.color; ctx.lineWidth = 3; ctx.stroke(); }
-    if (plant.main) {
-      const h = selected ? 30 : 20, w = h * (plant.main.w / plant.main.h);
-      drawFrame(plant.main.sheet, plant.main, x - w / 2, row - h / 2, w, h);
-    }
-    const demand = ordersNeeding(plant.name).reduce((a, o) => a + o.need, 0);
+    if (plant.main) { const h = selected ? 30 : 20, w = h * (plant.main.w / plant.main.h); drawFrame(plant.main.sheet, plant.main, x - w / 2, row - h / 2, w, h); }
+    const demand = Sim.ordersNeeding(game, plant.name).reduce((a, o) => a + o.need, 0);
     if (demand > 0) {
-      ctx.fillStyle = "#e74c3c";
-      ctx.beginPath(); ctx.arc(x + r * 0.8, row - r * 0.8, 9, 0, Math.PI * 2); ctx.fill();
-      ctx.fillStyle = "#fff"; ctx.font = "bold 10px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
-      ctx.fillText(demand, x + r * 0.8, row - r * 0.8 + 4);
+      ctx.fillStyle = "#e74c3c"; ctx.beginPath(); ctx.arc(x + r * 0.8, row - r * 0.8, 9, 0, Math.PI * 2); ctx.fill();
+      ctx.fillStyle = "#fff"; ctx.font = "bold 10px Trebuchet MS, sans-serif"; ctx.textAlign = "center"; ctx.fillText(demand, x + r * 0.8, row - r * 0.8 + 4);
     }
   }
   const sel = PLANTS[idx];
@@ -1139,12 +566,8 @@ function bar(x, y, w, h, t, fill, bg) {
 }
 function roundRect(x, y, w, h, r, doFill, doStroke) {
   ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.arcTo(x + w, y, x + w, y + h, r);
-  ctx.arcTo(x + w, y + h, x, y + h, r);
-  ctx.arcTo(x, y + h, x, y, r);
-  ctx.arcTo(x, y, x + w, y, r);
-  ctx.closePath();
+  ctx.moveTo(x + r, y); ctx.arcTo(x + w, y, x + w, y + h, r); ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r); ctx.arcTo(x, y, x + w, y, r); ctx.closePath();
   if (doFill) ctx.fill();
   if (doStroke) ctx.stroke();
 }
@@ -1154,15 +577,11 @@ function roundRect(x, y, w, h, r, doFill, doStroke) {
 // ---------------------------------------------------------------------------
 let lastTime = 0;
 let running = false;
-
 function loop(now) {
   if (!running) return;
   const dt = Math.min(0.05, (now - lastTime) / 1000 || 0);
   lastTime = now;
-  if (pressed("p") && gameState === "playing") togglePause();
-  update(dt);
-  if (game) render();
-  clearJustPressed();
+  stepGame(dt, true, true);
   requestAnimationFrame(loop);
 }
 
@@ -1170,15 +589,15 @@ function togglePause() {
   if (!game || gameState !== "playing") return;
   game.paused = !game.paused;
   pauseScreen.classList.toggle("hidden", !game.paused);
-  if (game.paused) { sound.footstepsOff(); for (const k in ASSETS.audio) ASSETS.audio[k].pause(); }
+  if (game.paused) { footActive = false; sound.footstepsOff(); for (const k in ASSETS.audio) ASSETS.audio[k].pause(); }
   else if (!sound.muted) sound.theme();
 }
 
 // ---------------------------------------------------------------------------
 // Menu wiring
 // ---------------------------------------------------------------------------
-let selectedPlayers = 1;   // player count (co-op)
-let selectedDifficulty = 1; // difficulty (mult / order pacing)
+let selectedPlayers = 1;
+let selectedDifficulty = 1;
 function bindChoiceGroup(selector, attr, setter) {
   document.querySelectorAll(selector).forEach((btn) => {
     btn.addEventListener("click", () => {
@@ -1203,13 +622,7 @@ function bindTouch() {
   if (!touchControls) return;
   touchControls.querySelectorAll(".tbtn").forEach((btn) => {
     const key = btn.dataset.key;
-    const press = (e) => {
-      e.preventDefault();
-      if (!keys[key]) justPressed[key] = true;
-      keys[key] = true;
-      btn.classList.add("pressed");
-      try { btn.setPointerCapture(e.pointerId); } catch (_) {}
-    };
+    const press = (e) => { e.preventDefault(); if (!keys[key]) justPressed[key] = true; keys[key] = true; btn.classList.add("pressed"); try { btn.setPointerCapture(e.pointerId); } catch (_) {} };
     const release = (e) => { e.preventDefault(); keys[key] = false; btn.classList.remove("pressed"); };
     btn.addEventListener("pointerdown", press);
     btn.addEventListener("pointerup", release);
@@ -1243,11 +656,7 @@ function bindJoystick() {
     touchMove.x = ux * m; touchMove.y = uy * m;
     knob.style.transform = `translate(${ux * m * R}px, ${uy * m * R}px)`;
   };
-  const end = (e) => {
-    e.preventDefault();
-    touchMove.active = false; touchMove.x = 0; touchMove.y = 0;
-    knob.style.transform = "translate(0,0)";
-  };
+  const end = (e) => { e.preventDefault(); touchMove.active = false; touchMove.x = 0; touchMove.y = 0; knob.style.transform = "translate(0,0)"; };
   js.addEventListener("pointerdown", start);
   js.addEventListener("pointermove", move);
   js.addEventListener("pointerup", end);
@@ -1255,9 +664,7 @@ function bindJoystick() {
 }
 bindJoystick();
 
-function showTouchControls(on) {
-  if (touchControls) touchControls.classList.toggle("active", on);
-}
+function showTouchControls(on) { if (touchControls) touchControls.classList.toggle("active", on && selectedPlayers === 1); }
 
 function startGame() {
   if (!ASSETS.atlas) return;
@@ -1270,15 +677,14 @@ function startGame() {
   if (actx && actx.state === "suspended") actx.resume().catch(() => {});
   sound.setMuted(muteBox.checked);
   if (!sound.muted) sound.theme();
+  footActive = false;
   running = true;
   lastTime = performance.now();
   requestAnimationFrame(loop);
 }
 
 function quitToMenu() {
-  running = false;
-  game = null;
-  gameState = "menu";
+  running = false; game = null; gameState = "menu";
   for (const k in ASSETS.audio) { ASSETS.audio[k].pause(); ASSETS.audio[k].currentTime = 0; }
   showTouchControls(false);
   pauseScreen.classList.add("hidden");
@@ -1294,46 +700,35 @@ ctx.fillRect(0, 0, WORLD.w, WORLD.h);
 
 if (location.search.includes("debug")) {
   const params = new URLSearchParams(location.search);
-  if (params.has("seed")) seedRng(parseInt(params.get("seed"), 10));
+  if (params.has("seed")) { pendingSeed = parseInt(params.get("seed"), 10); Sim.seedRng(pendingSeed); }
 
   window.__OG__ = {
     get game() { return game; },
-    get gameState() { return gameState; },
-    get PLANTS() { return PLANTS; },
-    // Constants exposed so the harness reports against live tuning values.
+    get gameState() { return game && game.over ? "result" : gameState; },
+    get PLANTS() { return Sim.PLANTS; },
     TUNE, ROUND, ORDER, WORLD, HOLD, STAGE, COOP,
-    starGoals,
-    // Raw input maps so an external bot can drive via the same input path the
-    // human uses (movement runs at real game speed — realistic for balancing).
+    starGoals: () => Sim.starGoals(game),
     keys, justPressed,
     teleport(x, y) { game.player.x = x; game.player.y = y; },
     openSeedMenu(i = 0) { game.player.seedMenu.open = true; game.player.seedMenu.index = i; },
     setPlot(i, patch) { Object.assign(game.plots[i], patch); },
     setTime(t) { game.time = t; },
-    spawnOrder,
+    spawnOrder() { Sim.spawnOrder(game); },
     addScore(n) { game.score += n; },
-    seedRng,
-    assetsReady() { return !!ASSETS.atlas && PLANTS.length > 0; },
-    // Start a round without the rAF loop or audio; the harness drives time via
-    // tick(dt) so a 150s round runs deterministically in a fraction of a second.
-    // `players` here means DIFFICULTY (back-compat with the harness); the bot
-    // drives a single co-op slot.
+    seedRng: Sim.seedRng,
+    assetsReady() { return !!ASSETS.atlas && Sim.PLANTS.length > 0; },
     startHeadless({ players = 1, seed = null } = {}) {
-      if (seed != null) seedRng(seed);
-      selectedDifficulty = players;
+      if (seed != null) pendingSeed = seed;
+      selectedDifficulty = players; selectedPlayers = 1;
       sound.setMuted(true);
       game = createGame(1, players);
       gameState = "playing";
       running = false;
-      startScreen.classList.add("hidden");
-      pauseScreen.classList.add("hidden");
-      resultScreen.classList.add("hidden");
+      startScreen.classList.add("hidden"); pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");
       return true;
     },
-    // Headless co-op: N bot-driven slots. The balancing harness injects one
-    // intent per player each tick via setBotIntents before calling tick().
     startHeadlessCoop({ count = 2, difficulty = 1, seed = null } = {}) {
-      if (seed != null) seedRng(seed);
+      if (seed != null) pendingSeed = seed;
       selectedPlayers = count; selectedDifficulty = difficulty;
       sound.setMuted(true);
       game = createGame(count, difficulty);
@@ -1341,20 +736,13 @@ if (location.search.includes("debug")) {
       game._botIntents = [];
       gameState = "playing";
       running = false;
-      startScreen.classList.add("hidden");
-      pauseScreen.classList.add("hidden");
-      resultScreen.classList.add("hidden");
+      startScreen.classList.add("hidden"); pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");
       return true;
     },
     setBotIntents(arr) { game._botIntents = arr; },
-    // One deterministic frame. Mirrors loop() but with a caller-supplied dt and
-    // optional rendering (skip it for fast data-only runs).
     tick(dt, doRender = false) {
-      if (pressed("p") && gameState === "playing") togglePause();
-      update(dt);
-      if (doRender && game) render();
-      clearJustPressed();
-      return gameState;
+      stepGame(dt, doRender, false);
+      return game && game.over ? "result" : "playing";
     },
   };
 }

--- a/web/game.js
+++ b/web/game.js
@@ -8,6 +8,7 @@
  * doesn't: canvas drawing, the input->intent layer, audio, and the DOM screens.
  */
 import * as Sim from "./sim.js";
+import { Net } from "./net.js";
 
 const { HOLD, STAGE, WORLD, TUNE, ROUND, ORDER, COOP } = Sim;
 
@@ -691,6 +692,80 @@ function quitToMenu() {
   resultScreen.classList.add("hidden");
   startScreen.classList.remove("hidden");
 }
+
+// ---------------------------------------------------------------------------
+// Online (authoritative server: send this device's intent, render snapshots)
+// ---------------------------------------------------------------------------
+let online = false;
+
+// One intent from the local device (keyboard WASD/arrows + touch + gamepad 0).
+function localIntent() {
+  const gp = gamepadIntent(0);
+  if (gp && (gp.mx || gp.my || gp.interact || gp.drop || gp.run || gp.navL || gp.navR)) return gp;
+  const km = keymapForSlot(0, 1);
+  const it = {
+    mx: (anyDown(km.right) ? 1 : 0) - (anyDown(km.left) ? 1 : 0),
+    my: (anyDown(km.down) ? 1 : 0) - (anyDown(km.up) ? 1 : 0),
+    run: anyDown(km.run), interact: anyPressed(km.interact), drop: anyPressed(km.drop),
+    navL: anyPressed(km.navL), navR: anyPressed(km.navR), confirm: anyPressed(km.confirm),
+  };
+  if (touchMove.active && Math.hypot(touchMove.x, touchMove.y) > 0.22) { it.mx = touchMove.x; it.my = touchMove.y; }
+  return it;
+}
+
+let _onlineEnded = false;
+function onlineLoop() {
+  if (!online) return;
+  if (Net.phase === "playing" || Net.phase === "result") {
+    const s = Net.renderState();
+    if (s) {
+      game = s;
+      if (!sound.muted) playEvents();
+      else game.events.length = 0;
+      gameState = "playing";
+      render();
+      if (Net.phase === "playing") Net.sendIntent(localIntent());
+    }
+    if (Net.phase === "result" && !_onlineEnded) { _onlineEnded = true; showOnlineResult(); }
+    clearJustPressed();
+  }
+  requestAnimationFrame(onlineLoop);
+}
+
+function showOnlineResult() {
+  const r = (game && game.result) || Net.result;
+  if (!r) return;
+  document.getElementById("result-stars").innerHTML = [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
+  document.getElementById("result-score").textContent = "Score: " + r.score;
+  document.getElementById("result-stats").textContent = `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}`;
+  resultScreen.classList.remove("hidden");
+}
+
+function beginOnline() {
+  online = true; _onlineEnded = false; running = false; // stop any offline rAF
+  startScreen.classList.add("hidden"); pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");
+  if (actx && actx.state === "suspended") actx.resume().catch(() => {});
+  sound.setMuted(muteBox.checked);
+  showTouchControls(true);
+  requestAnimationFrame(onlineLoop);
+}
+
+// Default server URL: ?server=... overrides; else same host on :8787 (dev) or a
+// configured prod endpoint. Lobby UI (O-2) wires this to buttons.
+function serverUrl() {
+  const p = new URLSearchParams(location.search).get("server");
+  if (p) return p;
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${location.hostname}:8787`;
+}
+
+window.__OG_NET__ = {
+  Net,
+  async connectCreate(url, count, difficulty) { await Net.connect(url || serverUrl()); Net.on.snapshot = () => { if (!online) beginOnline(); }; Net.create(count, difficulty); },
+  async connectJoin(url, room) { await Net.connect(url || serverUrl()); Net.on.snapshot = () => { if (!online) beginOnline(); }; Net.join(room); },
+  start() { Net.start(); },
+  state() { return { room: Net.room, slot: Net.slot, host: Net.host, phase: Net.phase, count: Net.count, error: Net.error, snapshot: Net.lastSnapshot }; },
+};
 
 // ---------------------------------------------------------------------------
 // Boot

--- a/web/game.js
+++ b/web/game.js
@@ -608,7 +608,7 @@ function bindChoiceGroup(selector, attr, setter) {
     });
   });
 }
-bindChoiceGroup(".count-btn", "count", (v) => { selectedPlayers = v; });
+bindChoiceGroup(".count-btn", "count", (v) => { selectedPlayers = v; const cc = document.getElementById("create-count"); if (cc) cc.textContent = v; });
 bindChoiceGroup(".diff-btn", "diff", (v) => { selectedDifficulty = v; });
 
 startBtn.addEventListener("click", startGame);
@@ -665,7 +665,7 @@ function bindJoystick() {
 }
 bindJoystick();
 
-function showTouchControls(on) { if (touchControls) touchControls.classList.toggle("active", on && selectedPlayers === 1); }
+function showTouchControls(on) { if (touchControls) touchControls.classList.toggle("active", on && (online || selectedPlayers === 1)); }
 
 function startGame() {
   if (!ASSETS.atlas) return;
@@ -685,9 +685,11 @@ function startGame() {
 }
 
 function quitToMenu() {
+  if (online) { try { Net.leave(); if (Net.ws) Net.ws.close(); } catch (_) {} online = false; }
   running = false; game = null; gameState = "menu";
   for (const k in ASSETS.audio) { ASSETS.audio[k].pause(); ASSETS.audio[k].currentTime = 0; }
   showTouchControls(false);
+  document.getElementById("again-btn").classList.remove("hidden");
   pauseScreen.classList.add("hidden");
   resultScreen.classList.add("hidden");
   startScreen.classList.remove("hidden");
@@ -738,12 +740,14 @@ function showOnlineResult() {
   document.getElementById("result-stars").innerHTML = [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
   document.getElementById("result-score").textContent = "Score: " + r.score;
   document.getElementById("result-stats").textContent = `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}`;
+  document.getElementById("again-btn").classList.add("hidden"); // server rooms don't restart
   resultScreen.classList.remove("hidden");
 }
 
 function beginOnline() {
   online = true; _onlineEnded = false; running = false; // stop any offline rAF
   startScreen.classList.add("hidden"); pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");
+  const os = document.getElementById("online-screen"); if (os) os.classList.add("hidden");
   if (actx && actx.state === "suspended") actx.resume().catch(() => {});
   sound.setMuted(muteBox.checked);
   showTouchControls(true);
@@ -766,6 +770,55 @@ window.__OG_NET__ = {
   start() { Net.start(); },
   state() { return { room: Net.room, slot: Net.slot, host: Net.host, phase: Net.phase, count: Net.count, error: Net.error, snapshot: Net.lastSnapshot }; },
 };
+
+// ---------------------------------------------------------------------------
+// Lobby UI
+// ---------------------------------------------------------------------------
+const onlineScreen = document.getElementById("online-screen");
+const onlineSetup = document.getElementById("online-setup");
+const onlineLobby = document.getElementById("online-lobby");
+const onlineError = document.getElementById("online-error");
+
+function showOnlineScreen(show) {
+  onlineScreen.classList.toggle("hidden", !show);
+  if (show) { onlineSetup.classList.remove("hidden"); onlineLobby.classList.add("hidden"); onlineError.textContent = ""; }
+}
+function showLobbyView() {
+  onlineSetup.classList.add("hidden"); onlineLobby.classList.remove("hidden");
+  document.getElementById("room-code").textContent = Net.room || "----";
+  document.getElementById("lobby-start").classList.toggle("hidden", !Net.host);
+  document.getElementById("lobby-wait").classList.toggle("hidden", Net.host);
+  document.getElementById("lobby-players").textContent = `Jogadores na sala: ${Net.slots ? Net.slots.length : 1} / ${Net.count}`;
+}
+function closeOnline() {
+  online = false;
+  try { Net.leave(); if (Net.ws) Net.ws.close(); } catch (_) {}
+}
+
+Net.on.joined = () => showLobbyView();
+Net.on.lobby = () => { if (Net.phase === "lobby") showLobbyView(); };
+Net.on.error = (msg) => { onlineError.textContent = msg; };
+
+async function connectThen(action) {
+  onlineError.textContent = "conectando…";
+  try {
+    await Net.connect(serverUrl());
+    onlineError.textContent = "";
+    Net.on.snapshot = () => { if (!online) beginOnline(); };
+    action();
+  } catch (_) { onlineError.textContent = "não foi possível conectar ao servidor"; }
+}
+
+document.getElementById("online-btn").addEventListener("click", () => { startScreen.classList.add("hidden"); showOnlineScreen(true); });
+document.getElementById("online-back").addEventListener("click", () => { try { if (Net.ws) Net.ws.close(); } catch (_) {} showOnlineScreen(false); startScreen.classList.remove("hidden"); });
+document.getElementById("create-room").addEventListener("click", () => connectThen(() => Net.create(selectedPlayers, selectedDifficulty)));
+document.getElementById("join-room").addEventListener("click", () => {
+  const code = document.getElementById("join-code").value.trim().toUpperCase();
+  if (code.length < 4) { onlineError.textContent = "digite o código (4 letras)"; return; }
+  connectThen(() => Net.join(code));
+});
+document.getElementById("lobby-start").addEventListener("click", () => Net.start());
+document.getElementById("lobby-leave").addEventListener("click", () => { closeOnline(); showOnlineScreen(false); startScreen.classList.remove("hidden"); });
 
 // ---------------------------------------------------------------------------
 // Boot

--- a/web/game.js
+++ b/web/game.js
@@ -102,15 +102,14 @@ const sound = {
   },
 };
 
-// Drain the sim's event queue into audio one-shots.
-function playEvents() {
-  for (const e of game.events) {
+// Play a list of sim sound events as one-shots.
+function playEvents(arr) {
+  for (const e of arr) {
     if (e === "pickup") sound.pickup();
     else if (e === "watering") sound.watering();
     else if (e === "ding") sound.ding();
     else if (e === "fail") sound.fail();
   }
-  game.events.length = 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,10 +228,11 @@ function stepGame(dt, doRender, withAudio) {
     const intents = gatherIntents();
     Sim.step(game, intents, dt);
     if (withAudio) {
-      playEvents();
+      playEvents(game.events);
       if (game.anyMoving && !footActive) { sound.footstepsOn(); footActive = true; }
       else if (!game.anyMoving && footActive) { sound.footstepsOff(); footActive = false; }
-    } else { game.events.length = 0; }
+    }
+    game.events.length = 0;
     if (game.over) finishRound();
   }
   if (doRender && game) render();
@@ -722,13 +722,15 @@ function onlineLoop() {
     const s = Net.renderState();
     if (s) {
       game = s;
-      if (!sound.muted) playEvents();
-      else game.events.length = 0;
       gameState = "playing";
+      // Footsteps from whether anyone is moving in the latest snapshot.
+      const moving = Net.lastSnapshot && Net.lastSnapshot.players.some((p) => p.moving);
+      if (moving && !footActive) { sound.footstepsOn(); footActive = true; }
+      else if (!moving && footActive) { sound.footstepsOff(); footActive = false; }
       render();
       if (Net.phase === "playing") Net.sendIntent(localIntent());
     }
-    if (Net.phase === "result" && !_onlineEnded) { _onlineEnded = true; showOnlineResult(); }
+    if (Net.phase === "result" && !_onlineEnded) { _onlineEnded = true; footActive = false; sound.footstepsOff(); showOnlineResult(); }
     clearJustPressed();
   }
   requestAnimationFrame(onlineLoop);
@@ -742,6 +744,13 @@ function showOnlineResult() {
   document.getElementById("result-stats").textContent = `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}`;
   document.getElementById("again-btn").classList.add("hidden"); // server rooms don't restart
   resultScreen.classList.remove("hidden");
+}
+
+// Fires once per snapshot: enter online play on the first one, and play the
+// sim's sound events (here, not per render frame, so they don't repeat).
+function onSnapshot(s) {
+  if (!online) beginOnline();
+  if (!sound.muted) playEvents(s.events || []);
 }
 
 function beginOnline() {
@@ -765,8 +774,8 @@ function serverUrl() {
 
 window.__OG_NET__ = {
   Net,
-  async connectCreate(url, count, difficulty) { await Net.connect(url || serverUrl()); Net.on.snapshot = () => { if (!online) beginOnline(); }; Net.create(count, difficulty); },
-  async connectJoin(url, room) { await Net.connect(url || serverUrl()); Net.on.snapshot = () => { if (!online) beginOnline(); }; Net.join(room); },
+  async connectCreate(url, count, difficulty) { await Net.connect(url || serverUrl()); Net.on.snapshot = onSnapshot; Net.create(count, difficulty); },
+  async connectJoin(url, room) { await Net.connect(url || serverUrl()); Net.on.snapshot = onSnapshot; Net.join(room); },
   start() { Net.start(); },
   state() { return { room: Net.room, slot: Net.slot, host: Net.host, phase: Net.phase, count: Net.count, error: Net.error, snapshot: Net.lastSnapshot }; },
 };
@@ -798,13 +807,26 @@ function closeOnline() {
 Net.on.joined = () => showLobbyView();
 Net.on.lobby = () => { if (Net.phase === "lobby") showLobbyView(); };
 Net.on.error = (msg) => { onlineError.textContent = msg; };
+Net.on.close = (info) => {
+  if (!info || info.intentional || !info.wasInGame) return;
+  // Lost connection mid-game: drop back to the online screen with the code
+  // prefilled so the player can rejoin (the server keeps the room running and
+  // allows drop-in into the freed slot).
+  online = false;
+  pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");
+  document.getElementById("again-btn").classList.remove("hidden");
+  startScreen.classList.add("hidden");
+  showOnlineScreen(true);
+  if (info.room) document.getElementById("join-code").value = info.room;
+  onlineError.textContent = "conexão perdida — reentre na sala";
+};
 
 async function connectThen(action) {
   onlineError.textContent = "conectando…";
   try {
     await Net.connect(serverUrl());
     onlineError.textContent = "";
-    Net.on.snapshot = () => { if (!online) beginOnline(); };
+    Net.on.snapshot = onSnapshot;
     action();
   } catch (_) { onlineError.textContent = "não foi possível conectar ao servidor"; }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -33,6 +33,7 @@
         <button class="diff-btn" data-diff="4">Insano</button>
       </div>
       <button id="start-btn" class="big-btn" disabled>Carregando…</button>
+      <button id="online-btn" class="big-btn secondary">🌐 Jogar online</button>
       <div class="controls">
         <strong>P1:</strong> WASD mover · SHIFT correr · E interagir · Q largar · P pausar
         <br />
@@ -62,6 +63,29 @@
       <p id="result-stats" class="controls"></p>
       <button id="again-btn" class="big-btn">Jogar de novo</button>
       <button id="menu-btn" class="big-btn secondary">Menu</button>
+    </div>
+
+    <!-- Online lobby -->
+    <div id="online-screen" class="overlay hidden">
+      <h1>Online</h1>
+      <div id="online-setup">
+        <p class="desc">Joguem juntos na mesma fazenda. O host cria a sala e compartilha o código; os outros entram (celular funciona).</p>
+        <button id="create-room" class="big-btn">Criar sala (<span id="create-count">1</span> jog.)</button>
+        <div class="choices">
+          <input id="join-code" maxlength="4" placeholder="CÓDIGO" autocapitalize="characters" autocomplete="off" />
+          <button id="join-room" class="big-btn secondary">Entrar</button>
+        </div>
+        <p id="online-error" class="online-error"></p>
+        <button id="online-back" class="big-btn secondary">Voltar</button>
+      </div>
+      <div id="online-lobby" class="hidden">
+        <p class="desc">Compartilhe o código:</p>
+        <div id="room-code">----</div>
+        <p id="lobby-players" class="controls">Jogadores: 1</p>
+        <button id="lobby-start" class="big-btn">Começar</button>
+        <p id="lobby-wait" class="controls hidden">Aguardando o host começar…</p>
+        <button id="lobby-leave" class="big-btn secondary">Sair da sala</button>
+      </div>
     </div>
   </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -84,6 +84,6 @@
     submissão da Ludum Dare 46.
   </p>
 
-  <script src="game.js"></script>
+  <script type="module" src="game.js"></script>
 </body>
 </html>

--- a/web/net.js
+++ b/web/net.js
@@ -1,0 +1,85 @@
+"use strict";
+/*
+ * Client networking for online co-op. Connects to the authoritative server,
+ * sends this device's intent each frame, and turns incoming snapshots into a
+ * sim-shaped render state (plants by name -> objects) that the existing
+ * renderer can draw unchanged.
+ *
+ * The local client never steps the sim — the server is authoritative.
+ */
+import * as Sim from "./sim.js";
+
+let STATIONS = null;
+function stations() { if (!STATIONS) STATIONS = Sim.createState({ playerCount: 1 }).stations; return STATIONS; }
+let _byName = null;
+function plant(name) {
+  if (!name) return null;
+  if (!_byName) { _byName = new Map(); for (const p of Sim.PLANTS) _byName.set(p.name, p); }
+  return _byName.get(name) || null;
+}
+
+export const Net = {
+  ws: null, url: null,
+  room: null, slot: -1, host: false, count: 1, difficulty: 1,
+  phase: "menu", // menu | lobby | playing | result
+  slots: [], lastSnapshot: null, result: null, error: null,
+  on: {}, // callbacks: lobby, joined, snapshot, ended, error, close
+
+  connect(url) {
+    this.url = url;
+    return new Promise((resolve, reject) => {
+      let ws;
+      try { ws = new WebSocket(url); } catch (e) { reject(e); return; }
+      this.ws = ws;
+      ws.onopen = () => resolve();
+      ws.onerror = (e) => { if (this.on.error) this.on.error("conexão falhou"); reject(e); };
+      ws.onclose = () => { this.phase = "menu"; this.ws = null; if (this.on.close) this.on.close(); };
+      ws.onmessage = (ev) => this._recv(JSON.parse(ev.data));
+    });
+  },
+  _send(m) { if (this.ws && this.ws.readyState === 1) this.ws.send(JSON.stringify(m)); },
+  create(count, difficulty) { this._send({ t: "create", count, difficulty }); },
+  join(room) { this._send({ t: "join", room: (room || "").toUpperCase() }); },
+  setup(count, difficulty) { this._send({ t: "setup", count, difficulty }); },
+  start() { this._send({ t: "start" }); },
+  sendIntent(intent) { this._send({ t: "intent", intent }); },
+  leave() { this._send({ t: "leave" }); },
+
+  _recv(m) {
+    if (m.t === "joined") {
+      this.room = m.room; this.slot = m.slot; this.host = m.host; this.count = m.count; this.difficulty = m.difficulty;
+      this.phase = "lobby"; this.error = null;
+      if (this.on.joined) this.on.joined(m);
+    } else if (m.t === "lobby") {
+      this.count = m.count; this.difficulty = m.difficulty; this.slots = m.slots;
+      if (!m.started) this.phase = "lobby";
+      if (this.on.lobby) this.on.lobby(m);
+    } else if (m.t === "snapshot") {
+      this.lastSnapshot = m.s; this.phase = m.s.over ? "result" : "playing";
+      if (this.on.snapshot) this.on.snapshot(m.s);
+    } else if (m.t === "ended") {
+      this.result = m.result; this.phase = "result";
+      if (this.on.ended) this.on.ended(m.result);
+    } else if (m.t === "error") {
+      this.error = m.msg; if (this.on.error) this.on.error(m.msg);
+    } else if (m.t === "peer") {
+      if (this.on.peer) this.on.peer(m);
+    }
+  },
+
+  // Reconstruct a sim-shaped state from the latest snapshot so render() works.
+  renderState() {
+    const s = this.lastSnapshot;
+    if (!s) return null;
+    return {
+      time: s.time, score: s.score, combo: s.combo, playerCount: s.playerCount,
+      over: s.over, result: s.result,
+      particles: [], floaters: [], shake: 0, anyMoving: false,
+      stations: stations(),
+      players: s.players.map((p) => ({ ...p, heldSeed: plant(p.heldSeed), heldPlant: plant(p.heldPlant) })),
+      plots: s.plots.map((pl) => ({ ...pl, plant: plant(pl.plant) })),
+      orders: s.orders.map((o) => ({ ...o, plant: plant(o.plant) })),
+      events: s.events || [],
+    };
+  },
+};

--- a/web/net.js
+++ b/web/net.js
@@ -18,22 +18,31 @@ function plant(name) {
   return _byName.get(name) || null;
 }
 
+const INTERP_DELAY = 120; // ms render lag for smoothing 15Hz snapshots
+const lerp = (a, b, t) => a + (b - a) * t;
+
 export const Net = {
   ws: null, url: null,
   room: null, slot: -1, host: false, count: 1, difficulty: 1,
   phase: "menu", // menu | lobby | playing | result
   slots: [], lastSnapshot: null, result: null, error: null,
+  buffer: [], intentionalClose: false,
   on: {}, // callbacks: lobby, joined, snapshot, ended, error, close
 
   connect(url) {
-    this.url = url;
+    this.url = url; this.intentionalClose = false; this.buffer = [];
     return new Promise((resolve, reject) => {
       let ws;
       try { ws = new WebSocket(url); } catch (e) { reject(e); return; }
       this.ws = ws;
       ws.onopen = () => resolve();
       ws.onerror = (e) => { if (this.on.error) this.on.error("conexão falhou"); reject(e); };
-      ws.onclose = () => { this.phase = "menu"; this.ws = null; if (this.on.close) this.on.close(); };
+      ws.onclose = () => {
+        const wasInGame = this.phase === "playing" || this.phase === "lobby";
+        const intentional = this.intentionalClose;
+        this.ws = null; this.phase = "menu";
+        if (this.on.close) this.on.close({ intentional, wasInGame, room: this.room });
+      };
       ws.onmessage = (ev) => this._recv(JSON.parse(ev.data));
     });
   },
@@ -43,7 +52,8 @@ export const Net = {
   setup(count, difficulty) { this._send({ t: "setup", count, difficulty }); },
   start() { this._send({ t: "start" }); },
   sendIntent(intent) { this._send({ t: "intent", intent }); },
-  leave() { this._send({ t: "leave" }); },
+  leave() { this.intentionalClose = true; this._send({ t: "leave" }); },
+  close() { this.intentionalClose = true; if (this.ws) try { this.ws.close(); } catch (_) {} },
 
   _recv(m) {
     if (m.t === "joined") {
@@ -56,6 +66,8 @@ export const Net = {
       if (this.on.lobby) this.on.lobby(m);
     } else if (m.t === "snapshot") {
       this.lastSnapshot = m.s; this.phase = m.s.over ? "result" : "playing";
+      this.buffer.push({ t: (typeof performance !== "undefined" ? performance.now() : Date.now()), s: m.s });
+      if (this.buffer.length > 16) this.buffer.shift();
       if (this.on.snapshot) this.on.snapshot(m.s);
     } else if (m.t === "ended") {
       this.result = m.result; this.phase = "result";
@@ -67,19 +79,40 @@ export const Net = {
     }
   },
 
-  // Reconstruct a sim-shaped state from the latest snapshot so render() works.
+  // Reconstruct a sim-shaped state so render() works. Interpolates positions
+  // between the two snapshots straddling (now - INTERP_DELAY) for smoothness.
   renderState() {
-    const s = this.lastSnapshot;
-    if (!s) return null;
+    if (!this.lastSnapshot) return null;
+    const now = (typeof performance !== "undefined" ? performance.now() : Date.now()) - INTERP_DELAY;
+    let prev = null, base = this.lastSnapshot, alpha = 0;
+    if (this.buffer.length >= 2) {
+      let lo = null, hi = null;
+      for (const b of this.buffer) { if (b.t <= now) lo = b; else { hi = b; break; } }
+      if (lo && hi) { prev = lo.s; base = hi.s; alpha = (now - lo.t) / ((hi.t - lo.t) || 1); }
+      else base = this.buffer[this.buffer.length - 1].s; // not enough lead: latest
+    }
+    const s = base;
+    const pp = prev && prev.players, qp = prev && prev.plots, qo = prev && prev.orders;
     return {
       time: s.time, score: s.score, combo: s.combo, playerCount: s.playerCount,
       over: s.over, result: s.result,
       particles: [], floaters: [], shake: 0, anyMoving: false,
       stations: stations(),
-      players: s.players.map((p) => ({ ...p, heldSeed: plant(p.heldSeed), heldPlant: plant(p.heldPlant) })),
-      plots: s.plots.map((pl) => ({ ...pl, plant: plant(pl.plant) })),
-      orders: s.orders.map((o) => ({ ...o, plant: plant(o.plant) })),
-      events: s.events || [],
+      players: s.players.map((p, i) => {
+        const q = pp && pp[i];
+        return { ...p, x: q ? lerp(q.x, p.x, alpha) : p.x, y: q ? lerp(q.y, p.y, alpha) : p.y, anim: q ? lerp(q.anim, p.anim, alpha) : p.anim, heldSeed: plant(p.heldSeed), heldPlant: plant(p.heldPlant) };
+      }),
+      plots: s.plots.map((pl, i) => {
+        const q = qp && qp[i];
+        const progress = q && q.stage === pl.stage ? lerp(q.progress, pl.progress, alpha) : pl.progress;
+        const life = q ? lerp(q.life, pl.life, alpha) : pl.life;
+        return { ...pl, progress, life, plant: plant(pl.plant) };
+      }),
+      orders: s.orders.map((o) => {
+        const q = qo && qo.find((x) => x.id === o.id);
+        return { ...o, timeLeft: q ? lerp(q.timeLeft, o.timeLeft, alpha) : o.timeLeft, plant: plant(o.plant) };
+      }),
+      events: this.lastSnapshot.events || [],
     };
   },
 };

--- a/web/sim.js
+++ b/web/sim.js
@@ -1,0 +1,336 @@
+"use strict";
+/*
+ * Overgarden — pure simulation core (no DOM / canvas / audio).
+ *
+ * Runs identically in the browser (game.js renders it) and in Node (the
+ * authoritative co-op server steps it). All gameplay randomness goes through a
+ * per-state seedable RNG so rooms/headless runs are reproducible. Side effects
+ * a renderer cares about (sounds, FX bursts) are pushed onto `state.events`;
+ * the simulation itself never touches the DOM.
+ *
+ * ESM module: `import * as Sim from "./sim.js"` (browser) / "../web/sim.js" (server).
+ */
+
+export const HOLD = { NOTHING: 0, SEED: 1, WATER: 2, TOOL: 3, PLANT: 4 };
+export const STAGE = { VIRGIN: 1, TREATED: 2, SMALL: 3, MEDIUM: 4, GREAT: 5, READY: 6, DIED: 7 };
+export const DIFFICULTY_MULT = [4, 3, 2, 1];
+export const WORLD = { w: 960, h: 600 };
+
+export const TUNE = {
+  normalSpeed: 175, runSpeed: 320, maxStamina: 100, runDrain: 48, walkRegen: 14, idleRegen: 26,
+  growthBase: 1.1, lifeBase: 1.3, wiltGrace: 3.0, decayRampMin: 0.6, decayRampMax: 1.3, interactRadius: 72,
+};
+export const ROUND = { duration: 150, stars: [90, 200, 380] };
+export const ORDER = {
+  maxConcurrent: 4, baseReward: 70, unitReward: 10, expirePenalty: 60,
+  spawnStart: 8, spawnEnd: 4, timeBase: 22, timePerRarity: 9,
+  diffTime: [1.5, 1.2, 1.0, 0.8], diffSpawn: [1.3, 1.1, 0.95, 0.8], comboWindow: 12,
+};
+export const COOP = { spawnScale: [1, 0.72, 0.58, 0.5], concurrentBonus: [0, 2, 3, 4], starScale: [1, 1.8, 2.1, 2.6] };
+export const PLAYER_COLORS = ["#ffd24a", "#4ea8ff", "#ff6b6b", "#74e36b"];
+export const PLAYER_SPAWN = [[0, 30], [-70, 30], [70, 30], [0, 96]];
+export const ZERO_INTENT = () => ({ mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false });
+
+// Plants list (name + rarity drive gameplay; main/stages ride along for the
+// client renderer and are ignored by the server).
+export let PLANTS = [];
+export function setPlants(list) { PLANTS = list; }
+export function buildPlants(atlas) {
+  return Object.entries(atlas.plantData)
+    .map(([name, d]) => ({ name, rarity: d.rarity, main: d.main, stages: d.stages }))
+    .sort((a, b) => a.rarity - b.rarity || a.name.localeCompare(b.name));
+}
+
+// Seedable RNG (mulberry32). Module fallback for legacy callers; per-state when
+// createState is given a seed (required for independent server rooms).
+let _seedRng = null;
+function makeRng(seed) {
+  let a = (seed >>> 0) || 1;
+  return function () {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+export function seedRng(seed) { _seedRng = makeRng(seed); }
+function rng(s) { return s._rng ? s._rng() : (_seedRng ? _seedRng() : Math.random()); }
+
+// ---------------------------------------------------------------------------
+function ev(s, snd) { s.events.push(snd); }
+
+export function createState({ playerCount = 1, difficulty = 1, seed = null } = {}) {
+  playerCount = Math.max(1, Math.min(4, playerCount));
+  difficulty = Math.max(1, Math.min(4, difficulty));
+  const plots = [];
+  const cols = 3, rows = 2, startX = 300, startY = 215, gapX = 130, gapY = 150;
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) {
+    plots.push({ x: startX + c * gapX, y: startY + r * gapY, stage: STAGE.VIRGIN, plant: null, progress: 0, life: 1, wilt: 0 });
+  }
+  const stations = [
+    { type: "tool", x: 92, y: 250, label: "Ferramentas", icon: "shovel" },
+    { type: "seed", x: 92, y: 420, label: "Sementes", icon: "seed" },
+    { type: "water", x: 868, y: 320, label: "Poço", icon: "water" },
+    { type: "sales", x: 480, y: 548, label: "Entrega", icon: "bag" },
+  ];
+  const players = [];
+  for (let i = 0; i < playerCount; i++) {
+    const [ox, oy] = PLAYER_SPAWN[i];
+    players.push({
+      index: i, color: PLAYER_COLORS[i],
+      x: WORLD.w / 2 + ox, y: WORLD.h / 2 + oy,
+      speed: 0, stamina: TUNE.maxStamina, facing: "down", moving: false,
+      holding: HOLD.NOTHING, heldSeed: null, heldPlant: null, anim: 0, navLatch: false,
+      seedMenu: { open: false, index: 0 },
+    });
+  }
+  return {
+    _rng: seed != null ? makeRng(seed) : null,
+    mult: DIFFICULTY_MULT[difficulty - 1], difficulty, playerCount,
+    score: 0, paused: false, over: false, result: null,
+    time: ROUND.duration,
+    orders: [], orderId: 1, orderSpawnTimer: 3,
+    combo: 0, comboTimer: 0,
+    stats: { delivered: 0, expired: 0 },
+    particles: [], floaters: [], shake: 0, anyMoving: false,
+    players, plots, stations,
+    events: [],
+  };
+}
+
+// ---- helpers ---------------------------------------------------------------
+export function dist(ax, ay, bx, by) { return Math.hypot(ax - bx, ay - by); }
+function lerp(a, b, t) { return a + (b - a) * t; }
+function clamp01(t) { return Math.max(0, Math.min(1, t)); }
+export function roundProgress(s) { return clamp01(1 - s.time / ROUND.duration); }
+export function maxConcurrentOrders(s) { return ORDER.maxConcurrent + COOP.concurrentBonus[s.playerCount - 1]; }
+export function starGoals(s) { const k = COOP.starScale[s.playerCount - 1]; return ROUND.stars.map((v) => Math.round(v * k)); }
+export function stationOf(s, type) { return s.stations.find((x) => x.type === type); }
+export function ordersNeeding(s, name) { return s.orders.filter((o) => o.plant.name === name && o.need > 0); }
+
+export function nearestStation(s, p) {
+  let best = null, bd = TUNE.interactRadius;
+  for (const st of s.stations) { const d = dist(p.x, p.y, st.x, st.y); if (d < bd) { bd = d; best = st; } }
+  return best;
+}
+export function nearestPlot(s, p) {
+  let best = null, bd = TUNE.interactRadius;
+  for (const pl of s.plots) { const d = dist(p.x, p.y, pl.x, pl.y); if (d < bd) { bd = d; best = pl; } }
+  return best;
+}
+function growthTime(s, plot) { return TUNE.growthBase * plot.plant.rarity * s.mult; }
+function lifeTime(s, plot) { return TUNE.lifeBase * plot.plant.rarity * s.mult; }
+function decayMult(s) { return lerp(TUNE.decayRampMin, TUNE.decayRampMax, roundProgress(s)); }
+
+// ---- orders ----------------------------------------------------------------
+function orderableRarity(s) { const p = roundProgress(s); return p < 0.3 ? 1 : p < 0.6 ? 2 : 3; }
+function orderInterval(s) {
+  return lerp(ORDER.spawnStart, ORDER.spawnEnd, roundProgress(s)) * ORDER.diffSpawn[s.difficulty - 1] * COOP.spawnScale[s.playerCount - 1];
+}
+export function spawnOrder(s) {
+  if (s.orders.length >= maxConcurrentOrders(s)) return;
+  const pool = PLANTS.filter((p) => p.rarity <= orderableRarity(s));
+  const plant = pool[Math.floor(rng(s) * pool.length)];
+  const p = roundProgress(s);
+  let qty = 1;
+  if (p > 0.3 && rng(s) < 0.5) qty++;
+  if (p > 0.6 && rng(s) < 0.4) qty++;
+  const time = (ORDER.timeBase + ORDER.timePerRarity * plant.rarity) * ORDER.diffTime[s.difficulty - 1];
+  s.orders.push({ plant, need: qty, qty, timeLeft: time, maxTime: time, id: s.orderId++ });
+}
+
+function updateOrders(s, dt) {
+  s.orderSpawnTimer -= dt;
+  if (s.orderSpawnTimer <= 0) { spawnOrder(s); s.orderSpawnTimer = orderInterval(s); }
+  for (const o of s.orders) o.timeLeft -= dt;
+  for (let i = s.orders.length - 1; i >= 0; i--) {
+    if (s.orders[i].timeLeft <= 0) {
+      s.orders.splice(i, 1);
+      s.score = Math.max(0, s.score - ORDER.expirePenalty);
+      s.combo = 0; s.stats.expired++;
+      const st = stationOf(s, "sales");
+      spawnParticles(s, st.x, st.y - 12, { n: 12, color: "#e74c3c", speed: 130 });
+      spawnFloater(s, st.x, st.y - 30, "-" + ORDER.expirePenalty, "#e74c3c");
+      addShake(s, 8); ev(s, "fail");
+    }
+  }
+  if (s.comboTimer > 0) { s.comboTimer -= dt; if (s.comboTimer <= 0) s.combo = 0; }
+}
+
+function deliverPlant(s, p) {
+  if (p.holding !== HOLD.PLANT || !p.heldPlant) return;
+  const st = stationOf(s, "sales");
+  const matches = ordersNeeding(s, p.heldPlant.name);
+  if (matches.length === 0) { spawnFloater(s, st.x, st.y - 28, "sem pedido!", "#e7a76a"); return; }
+  matches.sort((a, b) => a.timeLeft - b.timeLeft);
+  const o = matches[0];
+  o.need--; s.score += ORDER.unitReward;
+  p.holding = HOLD.NOTHING; p.heldPlant = null;
+  spawnParticles(s, st.x, st.y - 12, { n: 6, color: "#9fe6ff", speed: 90 }); ev(s, "pickup");
+  if (o.need <= 0) completeOrder(s, o);
+}
+
+function completeOrder(s, o) {
+  const base = ORDER.baseReward * o.plant.rarity * o.qty;
+  const tip = Math.round(base * 0.5 * (o.timeLeft / o.maxTime));
+  s.combo++; s.comboTimer = ORDER.comboWindow;
+  const mult = 1 + 0.1 * Math.min(s.combo - 1, 9);
+  const total = Math.round((base + tip) * mult);
+  s.score += total; s.stats.delivered++;
+  const st = stationOf(s, "sales");
+  spawnParticles(s, st.x, st.y - 16, { n: 20, color: "#f7d774", speed: 150 });
+  spawnFloater(s, st.x, st.y - 34, "+" + total + (s.combo > 1 ? "  x" + s.combo : ""), "#f7d774");
+  addShake(s, 7); ev(s, "ding");
+  const idx = s.orders.indexOf(o);
+  if (idx >= 0) s.orders.splice(idx, 1);
+}
+
+// ---- interactions ----------------------------------------------------------
+function handleInteract(s, p, intent) {
+  if (intent.drop && p.holding !== HOLD.PLANT) { p.holding = HOLD.NOTHING; p.heldSeed = null; }
+  if (!intent.interact) return;
+  const st = nearestStation(s, p);
+  if (st) { interactStation(s, p, st); return; }
+  const plot = nearestPlot(s, p);
+  if (plot) interactPlot(s, p, plot);
+}
+function interactStation(s, p, st) {
+  switch (st.type) {
+    case "tool": if (p.holding !== HOLD.PLANT) { p.holding = HOLD.TOOL; p.heldSeed = null; ev(s, "pickup"); } break;
+    case "water": if (p.holding !== HOLD.PLANT) { p.holding = HOLD.WATER; p.heldSeed = null; ev(s, "pickup"); } break;
+    case "seed": if (p.holding !== HOLD.PLANT) p.seedMenu.open = true; break;
+    case "sales": deliverPlant(s, p); break;
+  }
+}
+function interactPlot(s, p, plot) {
+  if (plot.stage === STAGE.DIED) {
+    if (p.holding === HOLD.TOOL) { resetPlot(plot); p.holding = HOLD.NOTHING; ev(s, "pickup"); }
+    return;
+  }
+  if (p.holding === HOLD.TOOL && plot.stage === STAGE.VIRGIN) {
+    plot.stage = STAGE.TREATED; plot.life = 1; p.holding = HOLD.NOTHING; ev(s, "pickup");
+    spawnParticles(s, plot.x, plot.y, { n: 8, color: "#6b4a2b", speed: 70 }); return;
+  }
+  if (p.holding === HOLD.SEED && plot.stage === STAGE.TREATED && p.heldSeed) {
+    plot.plant = p.heldSeed; plot.stage = STAGE.SMALL; plot.progress = 0; plot.life = 1; plot.wilt = 0;
+    p.holding = HOLD.NOTHING; p.heldSeed = null; ev(s, "pickup");
+    spawnParticles(s, plot.x, plot.y - 6, { n: 8, color: "#5fd35f", speed: 80 }); return;
+  }
+  const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
+  if (p.holding === HOLD.WATER && growing) {
+    plot.life = 1; plot.wilt = 0; p.holding = HOLD.NOTHING; ev(s, "watering");
+    spawnParticles(s, plot.x, plot.y - 10, { n: 10, color: "#7ec8ff", speed: 110 }); return;
+  }
+  if (p.holding === HOLD.NOTHING && plot.stage === STAGE.READY) {
+    p.holding = HOLD.PLANT; p.heldPlant = plot.plant;
+    spawnParticles(s, plot.x, plot.y - 14, { n: 12, color: "#fff0a8", speed: 120 });
+    resetPlot(plot); ev(s, "pickup");
+  }
+}
+function resetPlot(plot) { plot.stage = STAGE.VIRGIN; plot.plant = null; plot.progress = 0; plot.life = 1; plot.wilt = 0; }
+function selectSeed(s, p) { p.holding = HOLD.SEED; p.heldSeed = PLANTS[p.seedMenu.index]; p.seedMenu.open = false; ev(s, "pickup"); }
+
+// ---- FX (pure math; renderer reads particles/floaters/shake) ---------------
+function spawnParticles(s, x, y, { n = 8, color = "#fff", speed = 100, gravity = 220 } = {}) {
+  for (let i = 0; i < n; i++) {
+    const a = Math.random() * Math.PI * 2, sp = speed * (0.4 + Math.random() * 0.6);
+    s.particles.push({ x, y, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp - speed * 0.3, life: 0.5 + Math.random() * 0.4, maxLife: 0.9, size: 2 + Math.random() * 3, color, gravity });
+  }
+}
+function spawnFloater(s, x, y, text, color) { s.floaters.push({ x, y, vy: -34, life: 1.2, maxLife: 1.2, text, color }); }
+function addShake(s, a) { s.shake = Math.min(12, s.shake + a); }
+function updateFX(s, dt) {
+  for (let i = s.particles.length - 1; i >= 0; i--) {
+    const p = s.particles[i]; p.vy += p.gravity * dt; p.x += p.vx * dt; p.y += p.vy * dt; p.life -= dt;
+    if (p.life <= 0) s.particles.splice(i, 1);
+  }
+  for (let i = s.floaters.length - 1; i >= 0; i--) {
+    const f = s.floaters[i]; f.y += f.vy * dt; f.life -= dt; if (f.life <= 0) s.floaters.splice(i, 1);
+  }
+  if (s.shake > 0) s.shake = Math.max(0, s.shake - 30 * dt);
+}
+
+// ---- per-player update -----------------------------------------------------
+function updateSeedMenu(s, p, intent) {
+  if (intent.navL) p.seedMenu.index = Math.max(0, p.seedMenu.index - 1);
+  if (intent.navR) p.seedMenu.index = Math.min(PLANTS.length - 1, p.seedMenu.index + 1);
+  if (Math.abs(intent.mx) > 0.55 && !p.navLatch) {
+    p.seedMenu.index = Math.max(0, Math.min(PLANTS.length - 1, p.seedMenu.index + (intent.mx > 0 ? 1 : -1)));
+    p.navLatch = true;
+  } else if (Math.abs(intent.mx) < 0.3) { p.navLatch = false; }
+  if (intent.confirm) selectSeed(s, p);
+}
+function updatePlayer(s, p, intent, dt) {
+  let dx = intent.mx, dy = intent.my;
+  const inMag = Math.hypot(dx, dy);
+  const analogMag = inMag > 0 ? Math.min(1, inMag) : 1;
+  p.moving = dx !== 0 || dy !== 0;
+  const running = intent.run && p.moving && p.stamina > 0;
+  if (running) {
+    p.speed = TUNE.runSpeed; p.stamina -= TUNE.runDrain * dt;
+    if (p.stamina <= 0) { p.stamina = 0; p.speed = TUNE.normalSpeed; }
+  } else {
+    p.speed = TUNE.normalSpeed; p.stamina += (p.moving ? TUNE.walkRegen : TUNE.idleRegen) * dt;
+  }
+  p.stamina = Math.max(0, Math.min(TUNE.maxStamina, p.stamina));
+  if (p.moving) {
+    const len = Math.hypot(dx, dy); dx /= len; dy /= len;
+    if (Math.abs(dx) > Math.abs(dy)) p.facing = dx < 0 ? "left" : "right";
+    else p.facing = dy < 0 ? "up" : "down";
+    const sp = p.speed * analogMag;
+    p.x += dx * sp * dt; p.y += dy * sp * dt; p.anim += dt * (running ? 12 : 8);
+  } else { p.anim += dt * 3; }
+  p.x = Math.max(28, Math.min(WORLD.w - 28, p.x));
+  p.y = Math.max(132, Math.min(WORLD.h - 28, p.y));
+}
+function updatePlots(s, dt) {
+  const decay = decayMult(s);
+  for (const plot of s.plots) {
+    const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
+    if (growing) {
+      if (plot.life > 0) {
+        plot.progress += dt / growthTime(s, plot);
+        if (plot.progress >= 1) { plot.progress = 0; plot.stage++; plot.life = 1; plot.wilt = 0; }
+        plot.life -= (dt / lifeTime(s, plot)) * decay;
+        if (plot.life < 0) plot.life = 0;
+      } else {
+        plot.wilt += dt;
+        if (plot.wilt >= TUNE.wiltGrace) {
+          plot.stage = STAGE.DIED; plot.wilt = 0;
+          spawnParticles(s, plot.x, plot.y - 8, { n: 8, color: "#7a5230", speed: 70 });
+        }
+      }
+    } else if (plot.stage === STAGE.TREATED) {
+      plot.life -= dt / (TUNE.lifeBase * 3 * s.mult);
+      if (plot.life <= 0) resetPlot(plot);
+    }
+  }
+}
+
+function endRound(s) {
+  s.over = true;
+  const goals = starGoals(s), sc = s.score;
+  const stars = sc >= goals[2] ? 3 : sc >= goals[1] ? 2 : sc >= goals[0] ? 1 : 0;
+  s.result = { score: sc, stars, goals, delivered: s.stats.delivered, expired: s.stats.expired };
+}
+
+// ---- main step -------------------------------------------------------------
+// `intents` is an array indexed by player slot (missing => idle).
+export function step(s, intents, dt) {
+  if (s.over || s.paused) return s;
+  s.time -= dt;
+  if (s.time <= 0) { s.time = 0; endRound(s); return s; }
+  updateFX(s, dt);
+  updateOrders(s, dt);
+  let anyMoving = false;
+  for (let i = 0; i < s.players.length; i++) {
+    const p = s.players[i], intent = (intents && intents[i]) || ZERO_INTENT();
+    if (p.seedMenu.open) { updateSeedMenu(s, p, intent); p.moving = false; continue; }
+    updatePlayer(s, p, intent, dt);
+    handleInteract(s, p, intent);
+    if (p.moving) anyMoving = true;
+  }
+  updatePlots(s, dt);
+  s.anyMoving = anyMoving;
+  return s;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -56,6 +56,7 @@ canvas#game {
 }
 
 .overlay.hidden { display: none; }
+.hidden { display: none !important; }
 
 .overlay h1 {
   font-size: clamp(34px, 7vw, 54px);
@@ -103,6 +104,30 @@ canvas#game {
 }
 
 .count-btn { min-width: 44px; }
+
+#room-code {
+  font-size: clamp(40px, 12vw, 72px);
+  font-weight: bold;
+  letter-spacing: 8px;
+  color: #f7d774;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 10px;
+  padding: 6px 18px;
+  margin: 6px 0;
+}
+#join-code {
+  text-transform: uppercase;
+  font-size: clamp(18px, 5vw, 24px);
+  letter-spacing: 6px;
+  width: 130px;
+  text-align: center;
+  padding: 8px;
+  border-radius: 6px;
+  border: 2px solid #5b7a45;
+  background: #2a3a1f;
+  color: #fff;
+}
+.online-error { color: #ff8a7a; min-height: 18px; font-weight: bold; }
 .diff-btn:hover, .count-btn:hover { background: #4d6a3c; }
 .diff-btn.selected, .count-btn.selected {
   background: #f7d774;


### PR DESCRIPTION
## O que é

Co-op **online** completo (O-0→O-3), com servidor **WebSocket autoritativo**, validando cada fase. Constrói sobre a arquitetura de intents do co-op local.

## Fases (cada uma validada)

- **O-0 — `web/sim.js`**: extrai o núcleo de simulação **puro** (estado + `update` determinístico + tuning), sem DOM/áudio/canvas. Roda igual no browser e no Node. Sons/FX viram eventos; RNG por-estado. `game.js` vira a camada de browser (módulo). *Validação: harness solo idêntico (90/84, mean 78).*
- **O-1 — servidor + protocolo**: `server/server.mjs` (salas, 1 estado autoritativo cada, passo fixo 30Hz dos intents, snapshots ~15Hz) + `web/net.js` (envia intent local, reconstrói snapshot p/ o `render()`). *Validação: 2 clientes veem o mesmo estado autoritativo.*
- **O-2 — lobby**: criar sala → código de 4 letras; entrar pelo código; slots remotos; touch no celular. *Validação: fluxo completo pela UI real.*
- **O-3 — polish**: **interpolação** (delay ~120ms suaviza os 15Hz), **drop-in/reconexão** (servidor é autoridade → host sair não encerra; reentra em slot livre). *Validação: teste de integração com 7 checks.*

## Por que servidor autoritativo (e não P2P)

Confiável no mobile (sem signaling/TURN/NAT), host sair não derruba a partida, e encaixa na arquitetura de intents. Servidor **portável** (Node+`ws` em Fly/Render/Railway; o GitHub Pages segue servindo o cliente). Ver `server/README.md`.

## Testes

- `npm run test:net` — sobe servidor + 2 clientes headless e valida criar/entrar/começar, **sincronização autoritativa**, continuidade após desconexão e **drop-in**. ✅ 7/7.
- **Adicionado ao workflow e2e** (roda a cada PR junto do balanceamento).
- Harness solo e co-op (offline) **inalterados**.

## Como rodar local

```bash
npm install
npm run server          # ws://0.0.0.0:8787
# abrir o jogo → "🌐 Jogar online" → criar/entrar por código
```

## Observações

- Pausa por gamepad só despausa via teclado (sabido).
- "Jogar de novo" fica oculto no online (salas do servidor não reiniciam — entrar de novo cria nova sala).
- Próx. hardening possível: auto-reconnect com backoff, TURN-less continua ok por ser WS.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_