### PR TITLE
Balanceamento por fase: metas de ★ calibradas por throughput medido

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "sweep:prod": "node tests/e2e/sweep.mjs --mode production",
     "sweep:insane": "node tests/e2e/sweep.mjs --players 4",
     "coop": "node tests/e2e/coop.mjs",
+    "levels": "node tests/e2e/levels.mjs",
     "server": "node server/server.mjs",
     "test:net": "node tests/net/online.mjs"
   },

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -90,6 +90,16 @@ goals. Throughput scales **sublinearly** (shared plots + one well), which is why
 > `setBotIntents()` — a separate path from the solo harness, so the per-PR e2e
 > is untouched.
 
+## Per-level balancing (`levels.mjs`)
+
+`npm run levels` roda o bot em **cada fase** de `web/assets/levels.json` (seeds
+fixos) e reporta a distribuição de score por fase + metas de ★ **sugeridas** a
+partir do throughput medido (★1 ≈ 0.6·mediana, ★2 ≈ run sólido, ★3 ≈ melhor run
+do bot — humanos batem o bot, então é alcançável). `--apply` reescreve as metas
+em `levels.json`. O bot é conservador (1 cultivo por vez), então é um piso
+amigável. O caminho headless aceita `levelId` (`startHeadless({levelId})`); o
+e2e por-PR (sem `levelId`) usa o nível default e fica intacto.
+
 ## Reproducibility
 
 Only gameplay-affecting randomness (the order stream) is seeded via a mulberry32

--- a/tests/e2e/bot.js
+++ b/tests/e2e/bot.js
@@ -133,7 +133,7 @@
 
       if (growingCount < GROW_CAP && unmet) {
         if (treated) {
-          this.wantSeedIndex = OG.PLANTS.findIndex((p) => p.name === unmet.plant.name);
+          this.wantSeedIndex = (OG.game.plantPool || OG.PLANTS).findIndex((p) => p.name === unmet.plant.name);
           goTo(station("seed").x, station("seed").y);
           return;
         }

--- a/tests/e2e/harness.js
+++ b/tests/e2e/harness.js
@@ -40,7 +40,7 @@
 
   function sample(OG, force) {
     const g = OG.game, S = OG.STAGE;
-    const elapsed = OG.ROUND.duration - g.time;
+    const elapsed = (g.duration || OG.ROUND.duration) - g.time;
     const last = M.series[M.series.length - 1];
     if (!force && last && elapsed - last.t < 1) return; // ~1s cadence
     const grow = g.plots.filter((p) => p.stage >= S.SMALL && p.stage < S.READY);
@@ -81,8 +81,8 @@
   }
 
   window.__OG_HARNESS__ = {
-    start({ players = 1, seed = null } = {}) {
-      window.__OG__.startHeadless({ players, seed });
+    start({ players = 1, seed = null, levelId = null } = {}) {
+      window.__OG__.startHeadless({ players, seed, levelId });
       init(window.__OG__);
       return true;
     },
@@ -98,9 +98,10 @@
       return { state: OG.gameState, time: OG.game ? OG.game.time : 0 };
     },
     metrics() {
-      const OG = window.__OG__, g = OG.game, R = OG.ROUND;
+      const OG = window.__OG__, g = OG.game;
+      const goals = OG.starGoals ? OG.starGoals() : OG.ROUND.stars;
       const s = g.score;
-      const stars = s >= R.stars[2] ? 3 : s >= R.stars[1] ? 2 : s >= R.stars[0] ? 1 : 0;
+      const stars = s >= goals[2] ? 3 : s >= goals[1] ? 2 : s >= goals[0] ? 1 : 0;
       const t = Math.max(1, M.ticks);
       return {
         summary: {

--- a/tests/e2e/levels.mjs
+++ b/tests/e2e/levels.mjs
@@ -1,0 +1,110 @@
+// Per-level balancing tool for the campaign.
+//
+// Runs the autoplayer bot across every stage in web/assets/levels.json over
+// several seeds and reports the score distribution per level, plus a SUGGESTED
+// set of star goals derived from measured bot throughput. The bot is a
+// deliberately conservative player (one crop at a time), so it's a low-ish
+// baseline — humans/co-op beat it — which makes for friendly campaign goals.
+//
+// Usage: node tests/e2e/levels.mjs [--seeds 1,2,3,4,5] [--apply]
+//   --apply  rewrites levels.json with the suggested goals.
+import { chromium } from "playwright";
+import http from "node:http";
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB_DIR = path.resolve(HERE, "../../web");
+const LEVELS_PATH = path.join(WEB_DIR, "assets/levels.json");
+
+const argv = process.argv.slice(2);
+const getArg = (n, d) => { const i = argv.indexOf(n); return i >= 0 && argv[i + 1] ? argv[i + 1] : d; };
+const SEEDS = getArg("--seeds", "1,2,3,4,5").split(",").map((s) => parseInt(s, 10));
+const APPLY = argv.includes("--apply");
+
+const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".json": "application/json", ".png": "image/png", ".wav": "audio/wav", ".mp3": "audio/mpeg", ".svg": "image/svg+xml" };
+function startServer() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = decodeURIComponent(req.url.split("?")[0]);
+      const file = path.join(WEB_DIR, path.normalize(url === "/" ? "/index.html" : url));
+      if (!file.startsWith(WEB_DIR)) { res.writeHead(403).end(); return; }
+      const body = await readFile(file);
+      res.writeHead(200, { "Content-Type": MIME[path.extname(file)] || "application/octet-stream" });
+      res.end(body);
+    } catch { res.writeHead(404).end(); }
+  });
+  return new Promise((r) => server.listen(0, "127.0.0.1", () => r(server)));
+}
+
+const mean = (a) => a.reduce((x, y) => x + y, 0) / a.length;
+const median = (a) => { const s = [...a].sort((x, y) => x - y); const m = s.length >> 1; return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2; };
+const r10 = (x) => Math.max(10, Math.round(x / 10) * 10);
+
+// Friendly campaign curve from the conservative bot baseline:
+//   ★1 = most runs clear it · ★2 ≈ a solid bot run · ★3 ≈ bot's best (humans beat it).
+function suggestGoals(scores) {
+  const md = median(scores), mx = Math.max(...scores);
+  let s1 = r10(md * 0.6);          // ★1: most runs clear it (gentle entry)
+  let s2 = r10(((md + mx) / 2) * 0.95); // ★2: a solid run
+  let s3 = r10(mx);                // ★3: the bot's best — humans beat the bot, so reachable
+  if (s2 <= s1) s2 = s1 + 20;
+  if (s3 <= s2) s3 = s2 + 30;
+  return [s1, s2, s3];
+}
+
+async function playLevel(browser, base, levelId, seed) {
+  const page = await browser.newPage({ viewport: { width: 980, height: 700 } });
+  await page.goto(`${base}/index.html?debug&seed=${seed}`);
+  await page.waitForFunction(() => window.__OG__ && window.__OG__.assetsReady(), null, { timeout: 30000 });
+  await page.addScriptTag({ path: path.join(HERE, "bot.js") });
+  await page.addScriptTag({ path: path.join(HERE, "harness.js") });
+  await page.evaluate((a) => window.__OG_HARNESS__.start({ seed: a.seed, levelId: a.levelId }), { seed, levelId });
+  await page.evaluate(() => window.__OG_HARNESS__.run({ untilTime: 0, render: false }));
+  const m = await page.evaluate(() => window.__OG_HARNESS__.metrics());
+  await page.close();
+  return m.summary;
+}
+
+async function main() {
+  const data = JSON.parse(await readFile(LEVELS_PATH, "utf8"));
+  const server = await startServer();
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const browser = await chromium.launch({ args: ["--no-sandbox"] });
+
+  console.log(`Bot por fase · seeds ${SEEDS.join(",")}\n`);
+  console.log("fase".padEnd(14), "dif", "dur", " mean  med  min  max", " entreg/perd", " atual→sugerido");
+  const updates = [];
+  for (const lv of data.levels) {
+    const scores = [], deliv = [], exp = [];
+    for (const seed of SEEDS) {
+      const s = await playLevel(browser, base, lv.id, seed);
+      scores.push(s.score); deliv.push(s.delivered); exp.push(s.expired);
+    }
+    const sug = suggestGoals(scores);
+    updates.push({ id: lv.id, stars: sug });
+    const row = [
+      lv.name.padEnd(14),
+      String(lv.difficulty ?? "-").padStart(3),
+      String(lv.duration).padStart(3),
+      `${Math.round(mean(scores))}`.padStart(5) + `${Math.round(median(scores))}`.padStart(5) + `${Math.min(...scores)}`.padStart(5) + `${Math.max(...scores)}`.padStart(5),
+      `  ${mean(deliv).toFixed(1)}/${mean(exp).toFixed(1)}`.padEnd(12),
+      ` [${lv.stars.join("/")}] → [${sug.join("/")}]`,
+    ];
+    console.log(row.join(" "));
+  }
+
+  await browser.close();
+  server.close();
+
+  if (APPLY) {
+    for (const u of updates) { const lv = data.levels.find((l) => l.id === u.id); lv.stars = u.stars; }
+    await writeFile(LEVELS_PATH, JSON.stringify(data, null, 2) + "\n");
+    console.log(`\nAplicado: metas sugeridas escritas em ${path.relative(process.cwd(), LEVELS_PATH)}`);
+  } else {
+    console.log(`\n(dry-run — rode com --apply pra escrever as metas sugeridas)`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/web/assets/levels.json
+++ b/web/assets/levels.json
@@ -5,79 +5,325 @@
       "name": "Quintal",
       "difficulty": 1,
       "duration": 120,
-      "stars": [50, 110, 190],
+      "stars": [
+        110,
+        230,
+        300
+      ],
       "plots": [
-        { "x": 380, "y": 250 }, { "x": 580, "y": 250 },
-        { "x": 380, "y": 410 }, { "x": 580, "y": 410 }
+        {
+          "x": 380,
+          "y": 250
+        },
+        {
+          "x": 580,
+          "y": 250
+        },
+        {
+          "x": 380,
+          "y": 410
+        },
+        {
+          "x": 580,
+          "y": 410
+        }
       ],
       "stations": [
-        { "type": "tool", "x": 92, "y": 250 }, { "type": "seed", "x": 92, "y": 420 },
-        { "type": "water", "x": 868, "y": 320 }, { "type": "sales", "x": 480, "y": 548 }
+        {
+          "type": "tool",
+          "x": 92,
+          "y": 250
+        },
+        {
+          "type": "seed",
+          "x": 92,
+          "y": 420
+        },
+        {
+          "type": "water",
+          "x": 868,
+          "y": 320
+        },
+        {
+          "type": "sales",
+          "x": 480,
+          "y": 548
+        }
       ],
-      "plantPool": ["Carrot", "Potato", "Tomato"]
+      "plantPool": [
+        "Carrot",
+        "Potato",
+        "Tomato"
+      ]
     },
     {
       "id": "fazenda",
       "name": "Fazenda",
       "difficulty": 1,
       "duration": 150,
-      "stars": [90, 200, 360],
+      "stars": [
+        50,
+        160,
+        250
+      ],
       "plots": [
-        { "x": 300, "y": 215 }, { "x": 430, "y": 215 }, { "x": 560, "y": 215 },
-        { "x": 300, "y": 365 }, { "x": 430, "y": 365 }, { "x": 560, "y": 365 }
+        {
+          "x": 300,
+          "y": 215
+        },
+        {
+          "x": 430,
+          "y": 215
+        },
+        {
+          "x": 560,
+          "y": 215
+        },
+        {
+          "x": 300,
+          "y": 365
+        },
+        {
+          "x": 430,
+          "y": 365
+        },
+        {
+          "x": 560,
+          "y": 365
+        }
       ],
       "stations": [
-        { "type": "tool", "x": 92, "y": 250 }, { "type": "seed", "x": 92, "y": 420 },
-        { "type": "water", "x": 868, "y": 320 }, { "type": "sales", "x": 480, "y": 548 }
+        {
+          "type": "tool",
+          "x": 92,
+          "y": 250
+        },
+        {
+          "type": "seed",
+          "x": 92,
+          "y": 420
+        },
+        {
+          "type": "water",
+          "x": 868,
+          "y": 320
+        },
+        {
+          "type": "sales",
+          "x": 480,
+          "y": 548
+        }
       ],
-      "plantPool": ["Carrot", "Potato", "Tomato", "Corn", "SuspeciousLemon"]
+      "plantPool": [
+        "Carrot",
+        "Potato",
+        "Tomato",
+        "Corn",
+        "SuspeciousLemon"
+      ]
     },
     {
       "id": "horta-dupla",
       "name": "Horta Dupla",
       "difficulty": 2,
       "duration": 150,
-      "stars": [140, 300, 520],
+      "stars": [
+        20,
+        90,
+        150
+      ],
       "plots": [
-        { "x": 340, "y": 200 }, { "x": 560, "y": 200 },
-        { "x": 340, "y": 330 }, { "x": 560, "y": 330 },
-        { "x": 340, "y": 460 }, { "x": 560, "y": 460 }
+        {
+          "x": 340,
+          "y": 200
+        },
+        {
+          "x": 560,
+          "y": 200
+        },
+        {
+          "x": 340,
+          "y": 330
+        },
+        {
+          "x": 560,
+          "y": 330
+        },
+        {
+          "x": 340,
+          "y": 460
+        },
+        {
+          "x": 560,
+          "y": 460
+        }
       ],
       "stations": [
-        { "type": "tool", "x": 92, "y": 250 }, { "type": "seed", "x": 92, "y": 420 },
-        { "type": "water", "x": 868, "y": 320 }, { "type": "sales", "x": 480, "y": 548 }
+        {
+          "type": "tool",
+          "x": 92,
+          "y": 250
+        },
+        {
+          "type": "seed",
+          "x": 92,
+          "y": 420
+        },
+        {
+          "type": "water",
+          "x": 868,
+          "y": 320
+        },
+        {
+          "type": "sales",
+          "x": 480,
+          "y": 548
+        }
       ],
-      "plantPool": ["Carrot", "Potato", "Tomato", "Corn", "SuspeciousLemon", "Aubergine", "Pepper", "GrapeTomato"]
+      "plantPool": [
+        "Carrot",
+        "Potato",
+        "Tomato",
+        "Corn",
+        "SuspeciousLemon",
+        "Aubergine",
+        "Pepper",
+        "GrapeTomato"
+      ]
     },
     {
       "id": "estufa",
       "name": "Estufa",
       "difficulty": 2,
       "duration": 150,
-      "stars": [180, 380, 640],
+      "stars": [
+        220,
+        370,
+        400
+      ],
       "plots": [
-        { "x": 280, "y": 230 }, { "x": 400, "y": 230 }, { "x": 520, "y": 230 }, { "x": 640, "y": 230 },
-        { "x": 280, "y": 390 }, { "x": 400, "y": 390 }, { "x": 520, "y": 390 }, { "x": 640, "y": 390 }
+        {
+          "x": 280,
+          "y": 230
+        },
+        {
+          "x": 400,
+          "y": 230
+        },
+        {
+          "x": 520,
+          "y": 230
+        },
+        {
+          "x": 640,
+          "y": 230
+        },
+        {
+          "x": 280,
+          "y": 390
+        },
+        {
+          "x": 400,
+          "y": 390
+        },
+        {
+          "x": 520,
+          "y": 390
+        },
+        {
+          "x": 640,
+          "y": 390
+        }
       ],
       "stations": [
-        { "type": "tool", "x": 92, "y": 250 }, { "type": "seed", "x": 92, "y": 420 },
-        { "type": "water", "x": 868, "y": 320 }, { "type": "sales", "x": 480, "y": 548 }
+        {
+          "type": "tool",
+          "x": 92,
+          "y": 250
+        },
+        {
+          "type": "seed",
+          "x": 92,
+          "y": 420
+        },
+        {
+          "type": "water",
+          "x": 868,
+          "y": 320
+        },
+        {
+          "type": "sales",
+          "x": 480,
+          "y": 548
+        }
       ],
-      "plantPool": ["Corn", "SuspeciousLemon", "Aubergine", "DarkCarrot", "GrapeTomato", "Pepper", "Sweetsop"]
+      "plantPool": [
+        "Corn",
+        "SuspeciousLemon",
+        "Aubergine",
+        "DarkCarrot",
+        "GrapeTomato",
+        "Pepper",
+        "Sweetsop"
+      ]
     },
     {
       "id": "mercado",
       "name": "Mercado",
       "difficulty": 3,
       "duration": 145,
-      "stars": [200, 420, 720],
+      "stars": [
+        10,
+        60,
+        120
+      ],
       "plots": [
-        { "x": 360, "y": 250 }, { "x": 480, "y": 250 }, { "x": 600, "y": 250 },
-        { "x": 360, "y": 400 }, { "x": 480, "y": 400 }, { "x": 600, "y": 400 }
+        {
+          "x": 360,
+          "y": 250
+        },
+        {
+          "x": 480,
+          "y": 250
+        },
+        {
+          "x": 600,
+          "y": 250
+        },
+        {
+          "x": 360,
+          "y": 400
+        },
+        {
+          "x": 480,
+          "y": 400
+        },
+        {
+          "x": 600,
+          "y": 400
+        }
       ],
       "stations": [
-        { "type": "tool", "x": 84, "y": 200 }, { "type": "seed", "x": 84, "y": 470 },
-        { "type": "water", "x": 876, "y": 200 }, { "type": "sales", "x": 876, "y": 470 }
+        {
+          "type": "tool",
+          "x": 84,
+          "y": 200
+        },
+        {
+          "type": "seed",
+          "x": 84,
+          "y": 470
+        },
+        {
+          "type": "water",
+          "x": 876,
+          "y": 200
+        },
+        {
+          "type": "sales",
+          "x": 876,
+          "y": 470
+        }
       ],
       "plantPool": null
     },
@@ -86,15 +332,70 @@
       "name": "Festival",
       "difficulty": 3,
       "duration": 160,
-      "stars": [260, 560, 920],
+      "stars": [
+        100,
+        180,
+        220
+      ],
       "plots": [
-        { "x": 300, "y": 200 }, { "x": 470, "y": 200 }, { "x": 640, "y": 200 },
-        { "x": 300, "y": 335 }, { "x": 470, "y": 335 }, { "x": 640, "y": 335 },
-        { "x": 300, "y": 470 }, { "x": 470, "y": 470 }, { "x": 640, "y": 470 }
+        {
+          "x": 300,
+          "y": 200
+        },
+        {
+          "x": 470,
+          "y": 200
+        },
+        {
+          "x": 640,
+          "y": 200
+        },
+        {
+          "x": 300,
+          "y": 335
+        },
+        {
+          "x": 470,
+          "y": 335
+        },
+        {
+          "x": 640,
+          "y": 335
+        },
+        {
+          "x": 300,
+          "y": 470
+        },
+        {
+          "x": 470,
+          "y": 470
+        },
+        {
+          "x": 640,
+          "y": 470
+        }
       ],
       "stations": [
-        { "type": "tool", "x": 92, "y": 250 }, { "type": "seed", "x": 92, "y": 420 },
-        { "type": "water", "x": 868, "y": 320 }, { "type": "sales", "x": 480, "y": 548 }
+        {
+          "type": "tool",
+          "x": 92,
+          "y": 250
+        },
+        {
+          "type": "seed",
+          "x": 92,
+          "y": 420
+        },
+        {
+          "type": "water",
+          "x": 868,
+          "y": 320
+        },
+        {
+          "type": "sales",
+          "x": 480,
+          "y": 548
+        }
       ],
       "plantPool": null
     }

--- a/web/game.js
+++ b/web/game.js
@@ -948,12 +948,13 @@ if (location.search.includes("debug")) {
     addScore(n) { game.score += n; },
     seedRng: Sim.seedRng,
     assetsReady() { return !!ASSETS.atlas && Sim.PLANTS.length > 0; },
-    startHeadless({ players = 1, seed = null } = {}) {
+    startHeadless({ players = 1, seed = null, levelId = null } = {}) {
       if (seed != null) pendingSeed = seed;
+      const level = levelId ? LEVELS.find((l) => l.id === levelId) : null;
       selectedDifficulty = players; selectedPlayers = 1;
-      currentMode = "quick"; currentLevelIndex = -1;
+      currentMode = level ? "campaign" : "quick"; currentLevelIndex = level ? LEVELS.indexOf(level) : -1;
       sound.setMuted(true);
-      game = createGame(1, { difficulty: players });
+      game = createGame(1, level ? { level } : { difficulty: players });
       gameState = "playing";
       running = false;
       startScreen.classList.add("hidden"); pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");


### PR DESCRIPTION
## O que é (Task 1 — balanceamento por fase)

Estende o harness pra medir **cada fase da campanha** com o bot e **calibra as metas de ★** ao throughput medido — como já fizemos no co-op. As metas anteriores eram chutes e estavam erradas (ex.: Horta Dupla pedia 140 pra ★1, mas o bot faz no máximo 152 no nível todo).

## Como funciona

- **`npm run levels`** (`tests/e2e/levels.mjs`): roda o bot em todas as fases (seeds fixos), reporta score por fase e sugere metas. `--apply` reescreve `levels.json`.
- Fórmula amigável (jogo casual): **★1 ≈ 0.6·mediana** (quase todo run pega), **★2 ≈ run sólido**, **★3 ≈ melhor run do bot** (humanos batem o bot conservador → 3★ alcançável).
- Harness/`startHeadless` agora aceitam `levelId` e usam `duration`/`starGoals` da fase. `bot.js` passou a indexar o pool de sementes da fase (`game.plantPool`).
- O e2e por-PR (sem `levelId`) continua no nível default → **comentário de balanceamento inalterado**.

## Metas medidas → aplicadas

| Fase | dif | bot mean/med/max | metas antigas | **novas** |
|---|---|---|---|---|
| Quintal | 1 | 154/180/300 | 50/110/190 | **110/230/300** |
| Fazenda | 1 | 110/84/247 | 90/200/360 | **50/160/250** |
| Horta Dupla | 2 | 49/30/152 | 140/300/520 | **20/90/150** |
| Estufa | 2 | 319/369/402 | 180/380/640 | **220/370/400** |
| Mercado | 3 | 45/0/121 | 200/420/720 | **10/60/120** |
| Festival | 3 | 126/163/215 | 260/560/920 | **100/180/220** |

## Observação (pra Task 2)

Os dados mostram que a **curva de dificuldade é irregular** pro bot: Estufa (mean 319) é um respiro, enquanto Horta Dupla (49) e Mercado (med 0, estações nos cantos) são picos. As metas agora são alcançáveis por fase, mas o *design* das fases (dificuldade/tempo/layout) pode ser suavizado — bom candidato pro próximo passo de conteúdo.

## Testes

- Harness default **idêntico** (90/84, mean 78) · teste de rede ok.
- Determinismo confirmado (mesma fase+seed → mesmo score).

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_