### PR TITLE
Eventos/clima dinâmicos + curva de fases recalibrada

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,7 +69,7 @@ sozinho ou em co-op, com caos crescente.
 **Jogabilidade**
 - [x] **Co-op online** (netcode) — servidor WebSocket autoritativo + interpolação + drop-in/reconexão (`server/`, `web/net.js`; ver `docs/COOP_DESIGN.md`).
 - [ ] Loja entre fases (upgrades de estação) e economia.
-- [ ] Chefes/eventos de fim de fase; fases temáticas (estações do ano, clima).
+- [x] **Eventos/clima dinâmicos** durante a fase (chuva rega tudo, seca acelera murcha, "rush" de pedidos dourados com bônus) — opt-in por fase via `levels.json` (`events`), refletidos no servidor online. Faltam: chefes de fim de fase, fases temáticas por estação.
 
 **Engenharia**
 - [ ] **Decisão de engine**: Canvas puro vs. Phaser/Pixi vs. voltar ao Unity WebGL (reaproveitar assets/animações).

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -53,7 +53,7 @@ function lobby(r) {
 function serialize(st) {
   return {
     time: st.time, score: st.score, combo: st.combo, over: st.over, result: st.result,
-    goals: Sim.starGoals(st), playerCount: st.playerCount,
+    goals: Sim.starGoals(st), playerCount: st.playerCount, weather: st.weather,
     levelName: st.levelName, plantPool: st.plantPool.map((p) => p.name),
     stations: st.stations.map((x) => ({ type: x.type, x: x.x, y: x.y, label: x.label, icon: x.icon })),
     players: st.players.map((p) => ({ index: p.index, color: p.color, x: Math.round(p.x * 10) / 10, y: Math.round(p.y * 10) / 10, facing: p.facing, moving: p.moving, holding: p.holding, heldSeed: p.heldSeed ? p.heldSeed.name : null, heldPlant: p.heldPlant ? p.heldPlant.name : null, stamina: Math.round(p.stamina), anim: Math.round(p.anim * 100) / 100, seedMenu: { open: p.seedMenu.open, index: p.seedMenu.index } })),

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -100,6 +100,11 @@ em `levels.json`. O bot é conservador (1 cultivo por vez), então é um piso
 amigável. O caminho headless aceita `levelId` (`startHeadless({levelId})`); o
 e2e por-PR (sem `levelId`) usa o nível default e fica intacto.
 
+As metas usam o **teto medido** (melhor run do bot entre os seeds — estável e
+determinístico, ao contrário da mediana, que colapsa em fases com eventos):
+★1≈0.30·max, ★2≈0.60·max, ★3≈0.92·max. Fases com `events` (chuva/seca/rush)
+mudam o throughput, então recalibre (`--apply`) após alterá-las.
+
 ## Reproducibility
 
 Only gameplay-affecting randomness (the order stream) is seeded via a mulberry32

--- a/tests/e2e/levels.mjs
+++ b/tests/e2e/levels.mjs
@@ -44,11 +44,15 @@ const r10 = (x) => Math.max(10, Math.round(x / 10) * 10);
 
 // Friendly campaign curve from the conservative bot baseline:
 //   ★1 = most runs clear it · ★2 ≈ a solid bot run · ★3 ≈ bot's best (humans beat it).
+// Fractions of the measured achievable ceiling (the bot's best of the seeds).
+// The bot is a conservative single-crop player and its medians collapse on
+// harder/eventful levels, so we anchor on its MAX (stable, deterministic) — a
+// reachable ceiling that humans comfortably beat.
 function suggestGoals(scores) {
-  const md = median(scores), mx = Math.max(...scores);
-  let s1 = r10(md * 0.6);          // ★1: most runs clear it (gentle entry)
-  let s2 = r10(((md + mx) / 2) * 0.95); // ★2: a solid run
-  let s3 = r10(mx);                // ★3: the bot's best — humans beat the bot, so reachable
+  const mx = Math.max(...scores);
+  let s1 = r10(mx * 0.30); // ★1: a real but easy target
+  let s2 = r10(mx * 0.60); // ★2: a solid run
+  let s3 = r10(mx * 0.92); // ★3: near the bot's best
   if (s2 <= s1) s2 = s1 + 20;
   if (s3 <= s2) s3 = s2 + 30;
   return [s1, s2, s3];

--- a/web/assets/levels.json
+++ b/web/assets/levels.json
@@ -6,10 +6,11 @@
       "difficulty": 1,
       "duration": 120,
       "stars": [
-        110,
-        230,
-        300
+        90,
+        180,
+        280
       ],
+      "events": [],
       "plots": [
         {
           "x": 380,
@@ -62,9 +63,12 @@
       "difficulty": 1,
       "duration": 150,
       "stars": [
-        50,
-        160,
-        250
+        90,
+        180,
+        270
+      ],
+      "events": [
+        "rain"
       ],
       "plots": [
         {
@@ -126,11 +130,15 @@
       "id": "horta-dupla",
       "name": "Horta Dupla",
       "difficulty": 2,
-      "duration": 150,
+      "duration": 160,
       "stars": [
-        20,
-        90,
-        150
+        120,
+        250,
+        380
+      ],
+      "events": [
+        "rain",
+        "rush"
       ],
       "plots": [
         {
@@ -197,9 +205,13 @@
       "difficulty": 2,
       "duration": 150,
       "stars": [
-        220,
-        370,
-        400
+        130,
+        270,
+        410
+      ],
+      "events": [
+        "rush",
+        "drought"
       ],
       "plots": [
         {
@@ -271,11 +283,15 @@
       "id": "mercado",
       "name": "Mercado",
       "difficulty": 3,
-      "duration": 145,
+      "duration": 155,
       "stars": [
-        10,
-        60,
-        120
+        50,
+        110,
+        160
+      ],
+      "events": [
+        "drought",
+        "rush"
       ],
       "plots": [
         {
@@ -325,17 +341,32 @@
           "y": 470
         }
       ],
-      "plantPool": null
+      "plantPool": [
+        "Carrot",
+        "Potato",
+        "Tomato",
+        "Corn",
+        "SuspeciousLemon",
+        "Aubergine",
+        "DarkCarrot",
+        "GrapeTomato",
+        "Pepper",
+        "Sweetsop"
+      ]
     },
     {
       "id": "festival",
       "name": "Festival",
       "difficulty": 3,
-      "duration": 160,
+      "duration": 170,
       "stars": [
-        100,
-        180,
-        220
+        110,
+        210,
+        330
+      ],
+      "events": [
+        "rain",
+        "rush"
       ],
       "plots": [
         {
@@ -397,7 +428,18 @@
           "y": 548
         }
       ],
-      "plantPool": null
+      "plantPool": [
+        "Carrot",
+        "Potato",
+        "Tomato",
+        "Corn",
+        "SuspeciousLemon",
+        "Aubergine",
+        "DarkCarrot",
+        "GrapeTomato",
+        "Pepper",
+        "Sweetsop"
+      ]
     }
   ]
 }

--- a/web/game.js
+++ b/web/game.js
@@ -327,8 +327,10 @@ function render() {
   drawParticles();
   drawFloaters();
   ctx.restore();
+  drawWeatherTint();
   drawHUD();
   drawOrders();
+  drawWeather();
   for (const p of game.players) drawInteractHint(p);
   for (const p of game.players) if (p.seedMenu.open) drawSeedMenu(p);
 }
@@ -466,6 +468,25 @@ function drawFloaters() {
 }
 
 function fmtTime(t) { const s = Math.max(0, Math.ceil(t)); return Math.floor(s / 60) + ":" + String(s % 60).padStart(2, "0"); }
+
+function weatherColor(type) { return type === "drought" ? "#e08a3c" : type === "rush" ? "#f7d774" : "#7ec8ff"; }
+function drawWeatherTint() {
+  const w = game.weather; if (!w) return;
+  const a = 0.5 + 0.5 * Math.sin(performance.now() / 600);
+  if (w.type === "drought") ctx.fillStyle = `rgba(224,138,60,${0.06 + 0.05 * a})`;
+  else if (w.type === "rain") ctx.fillStyle = `rgba(90,150,210,${0.06 + 0.04 * a})`;
+  else ctx.fillStyle = `rgba(247,215,116,${0.04 + 0.03 * a})`;
+  ctx.fillRect(0, 0, WORLD.w, WORLD.h);
+}
+function drawWeather() {
+  const w = game.weather; if (!w) return;
+  const txt = `${w.label} · ${Math.ceil(w.timeLeft)}s`;
+  ctx.font = "bold 18px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
+  const tw = ctx.measureText(txt).width, x = WORLD.w / 2, y = WORLD.h - 52, col = weatherColor(w.type);
+  ctx.fillStyle = "rgba(20,30,16,0.85)"; roundRect(x - tw / 2 - 16, y - 20, tw + 32, 30, 8, true, false);
+  ctx.strokeStyle = col; ctx.lineWidth = 2; roundRect(x - tw / 2 - 16, y - 20, tw + 32, 30, 8, false, true);
+  ctx.fillStyle = col; ctx.fillText(txt, x, y);
+}
 
 function drawHUD() {
   ctx.fillStyle = "rgba(20,30,16,0.75)"; roundRect(12, 10, 210, 44, 8, true, false);

--- a/web/net.js
+++ b/web/net.js
@@ -95,7 +95,7 @@ export const Net = {
     const pp = prev && prev.players, qp = prev && prev.plots, qo = prev && prev.orders;
     return {
       time: s.time, score: s.score, combo: s.combo, playerCount: s.playerCount,
-      over: s.over, result: s.result, levelName: s.levelName,
+      over: s.over, result: s.result, levelName: s.levelName, weather: s.weather,
       plantPool: s.plantPool ? s.plantPool.map(plant).filter(Boolean) : null,
       particles: [], floaters: [], shake: 0, anyMoving: false,
       stations: s.stations || stations(),

--- a/web/sim.js
+++ b/web/sim.js
@@ -27,6 +27,16 @@ export const ORDER = {
   diffTime: [1.5, 1.2, 1.0, 0.8], diffSpawn: [1.3, 1.1, 0.95, 0.8], comboWindow: 12,
 };
 export const COOP = { spawnScale: [1, 0.72, 0.58, 0.5], concurrentBonus: [0, 2, 3, 4], starScale: [1, 1.8, 2.1, 2.6] };
+// Dynamic events (opt-in per level via level.events: ["rain","drought","rush"]).
+// Levels without events behave exactly as before (default/quick/e2e untouched).
+export const EVENTS = {
+  interval: 32, // seconds between events; first one a bit sooner
+  defs: {
+    rain: { dur: 6, label: "🌧️ Chuva" },              // rega tudo que está crescendo
+    drought: { dur: 9, label: "☀️ Seca", decay: 1.35 }, // murcha acelera
+    rush: { dur: 14, label: "✨ Pedidos dourados", mult: 1.6 }, // entregas valem mais
+  },
+};
 export const PLAYER_COLORS = ["#ffd24a", "#4ea8ff", "#ff6b6b", "#74e36b"];
 export const PLAYER_SPAWN = [[0, 30], [-70, 30], [70, 30], [0, 96]];
 export const ZERO_INTENT = () => ({ mx: 0, my: 0, run: false, interact: false, drop: false, navL: false, navR: false, confirm: false });
@@ -106,6 +116,8 @@ export function createState({ playerCount = 1, difficulty = 1, seed = null, leve
     levelId: L.id, levelName: L.name, duration: L.duration, starsBase: L.stars.slice(),
     plantPool: pool.length ? pool : PLANTS.slice(),
     score: 0, paused: false, over: false, result: null,
+    eventTypes: (L.events || []).filter((t) => EVENTS.defs[t]),
+    eventTimer: EVENTS.interval * 0.55, weather: null,
     time: L.duration,
     orders: [], orderId: 1, orderSpawnTimer: 3,
     combo: 0, comboTimer: 0,
@@ -138,7 +150,24 @@ export function nearestPlot(s, p) {
 }
 function growthTime(s, plot) { return TUNE.growthBase * plot.plant.rarity * s.mult; }
 function lifeTime(s, plot) { return TUNE.lifeBase * plot.plant.rarity * s.mult; }
-function decayMult(s) { return lerp(TUNE.decayRampMin, TUNE.decayRampMax, roundProgress(s)); }
+function decayMult(s) {
+  const base = lerp(TUNE.decayRampMin, TUNE.decayRampMax, roundProgress(s));
+  return base * (s.weather && s.weather.type === "drought" ? EVENTS.defs.drought.decay : 1);
+}
+function rushMult(s) { return s.weather && s.weather.type === "rush" ? EVENTS.defs.rush.mult : 1; }
+function updateEvents(s, dt) {
+  if (!s.eventTypes.length) return;
+  if (s.weather) { s.weather.timeLeft -= dt; if (s.weather.timeLeft <= 0) s.weather = null; return; }
+  s.eventTimer -= dt;
+  if (s.eventTimer <= 0) {
+    const type = s.eventTypes[Math.floor(rng(s) * s.eventTypes.length)];
+    const def = EVENTS.defs[type];
+    s.weather = { type, label: def.label, timeLeft: def.dur, dur: def.dur };
+    s.eventTimer = EVENTS.interval;
+    if (type === "rain") for (const pl of s.plots) if (pl.stage >= STAGE.SMALL && pl.stage < STAGE.READY) { pl.life = 1; pl.wilt = 0; }
+    ev(s, "ding");
+  }
+}
 
 // ---- orders ----------------------------------------------------------------
 function orderableRarity(s) { const p = roundProgress(s); return p < 0.3 ? 1 : p < 0.6 ? 2 : 3; }
@@ -184,7 +213,7 @@ function deliverPlant(s, p) {
   if (matches.length === 0) { spawnFloater(s, st.x, st.y - 28, "sem pedido!", "#e7a76a"); return; }
   matches.sort((a, b) => a.timeLeft - b.timeLeft);
   const o = matches[0];
-  o.need--; s.score += ORDER.unitReward;
+  o.need--; s.score += Math.round(ORDER.unitReward * rushMult(s));
   p.holding = HOLD.NOTHING; p.heldPlant = null;
   spawnParticles(s, st.x, st.y - 12, { n: 6, color: "#9fe6ff", speed: 90 }); ev(s, "pickup");
   if (o.need <= 0) completeOrder(s, o);
@@ -195,7 +224,7 @@ function completeOrder(s, o) {
   const tip = Math.round(base * 0.5 * (o.timeLeft / o.maxTime));
   s.combo++; s.comboTimer = ORDER.comboWindow;
   const mult = 1 + 0.1 * Math.min(s.combo - 1, 9);
-  const total = Math.round((base + tip) * mult);
+  const total = Math.round((base + tip) * mult * rushMult(s));
   s.score += total; s.stats.delivered++;
   const st = stationOf(s, "sales");
   spawnParticles(s, st.x, st.y - 16, { n: 20, color: "#f7d774", speed: 150 });
@@ -342,6 +371,7 @@ export function step(s, intents, dt) {
   s.time -= dt;
   if (s.time <= 0) { s.time = 0; endRound(s); return s; }
   updateFX(s, dt);
+  updateEvents(s, dt);
   updateOrders(s, dt);
   let anyMoving = false;
   for (let i = 0; i < s.players.length; i++) {


### PR DESCRIPTION
## O que é (Task 2 — variedade + curva)

Adiciona **eventos/clima dinâmicos** durante a fase e recalibra a curva da campanha.

## Eventos (opt-in por fase via `levels.json` → `events`)

- **🌧️ Chuva** — rega tudo que está crescendo (alívio).
- **☀️ Seca** — acelera a murcha (×1.35 por ~9s).
- **✨ Pedidos dourados** — entregas valem +60% por ~14s.

Determinísticos (seeded), agendados a cada ~32s. O sim aplica os efeitos em `decayMult`/recompensas; o cliente mostra **banner + tint sutil**; o `weather` vai no snapshot, então o **online mostra o mesmo evento** pra todos. **Fases sem eventos (default/quick/e2e) ficam idênticas.**

## Curva recalibrada

- Eventos/durações/pools por fase ajustados pra escalonar.
- Metas de ★ recalibradas pelo **teto medido** (melhor run do bot, determinístico) em vez da mediana — que colapsa sob a variância dos eventos. `★1≈0.30·max · ★2≈0.60·max · ★3≈0.92·max` (achievable; humanos batem o bot conservador).

| Fase | eventos | metas ★ |
|---|---|---|
| Quintal | — | 90/180/280 |
| Fazenda | chuva | 90/180/270 |
| Horta Dupla | chuva, rush | 120/250/380 |
| Estufa | rush, seca | 130/270/410 |
| Mercado | seca, rush | 50/110/160 |
| Festival | chuva, rush | 110/210/330 |

> Mercado tem teto mais baixo (diff3 + estações nos cantos = caminhada) — por isso metas menores. A curva não é estritamente monotônica porque cada fase é calibrada ao que é alcançável nela; o progresso é em ★, não em score bruto.

## Testes

- e2e default **idêntico** (90/84, mean 78 — sem eventos lá).
- Teste de rede ok (online carrega eventos da fase escolhida).
- Evento ativa e renderiza em jogo (screenshot no PR).

## Nota honesta

O bot é um jogador conservador (1 cultivo por vez), então é um piso amigável e subrepresenta o jogo humano com vários canteiros. Metas ficaram generosas de propósito (casual). Curva fina de verdade pede playtest humano/telemetria.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_