### PR TITLE
Telemetria de rodada + tela de estatísticas (playtest)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,7 +73,7 @@ sozinho ou em co-op, com caos crescente.
 
 **Engenharia**
 - [ ] **Decisão de engine**: Canvas puro vs. Phaser/Pixi vs. voltar ao Unity WebGL (reaproveitar assets/animações).
-- [ ] Telemetria + funil (A/B de balanceamento); save na nuvem se houver contas.
+- [x] Telemetria de rodada (`web/telemetry.js`): eventos start/end por fase, ring buffer local + sink por beacon (`?telemetry=URL`) pronto pra backend, e tela "📊 Estatísticas" pra playtest. Falta: funil/A-B e save na nuvem.
 - [ ] **PWA** (instalável/offline); otimização mobile; pipeline de release versionado.
 
 **Marketing / distribuição**

--- a/web/game.js
+++ b/web/game.js
@@ -9,6 +9,7 @@
  */
 import * as Sim from "./sim.js";
 import { Net } from "./net.js";
+import { Telemetry } from "./telemetry.js";
 
 const { HOLD, STAGE, WORLD, TUNE, ROUND, ORDER, COOP } = Sim;
 
@@ -213,6 +214,17 @@ let footActive = false;
 let LEVELS = [];
 let currentMode = "quick"; // quick | campaign | online
 let currentLevelIndex = -1;
+let humanSession = false;  // true only for real play (gates telemetry off in headless)
+
+function trackRoundStart() {
+  if (!humanSession || !game) return;
+  Telemetry.track("round_start", { mode: currentMode, level: game.levelId, levelName: game.levelName, players: game.playerCount, difficulty: game.difficulty });
+}
+function trackRoundEnd() {
+  if (!humanSession || !game || !game.result) return;
+  const r = game.result;
+  Telemetry.track("round_end", { mode: currentMode, level: game.levelId || game.levelName, levelName: game.levelName, players: game.playerCount, score: r.score, stars: r.stars, delivered: r.delivered, expired: r.expired });
+}
 
 function createGame(playerCount, { difficulty = 1, level = null } = {}) {
   const s = Sim.createState({ playerCount, difficulty, seed: pendingSeed, level });
@@ -256,6 +268,7 @@ function finishRound() {
   for (const k in ASSETS.audio) ASSETS.audio[k].pause();
   showTouchControls(false);
   const r = game.result;
+  trackRoundEnd();
   if (currentMode === "campaign" && currentLevelIndex >= 0) saveStars(LEVELS[currentLevelIndex].id, r.stars);
   document.getElementById("result-stars").innerHTML =
     [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
@@ -695,6 +708,38 @@ function openCampaign() {
 document.getElementById("campaign-btn").addEventListener("click", openCampaign);
 document.getElementById("campaign-back").addEventListener("click", () => { campaignScreen.classList.add("hidden"); startScreen.classList.remove("hidden"); });
 
+// ---- Local stats (playtest) ----
+const statsScreen = document.getElementById("stats-screen");
+function buildStats() {
+  const sum = Telemetry.summary();
+  document.getElementById("stats-overall").textContent =
+    sum.totalPlays ? `${sum.totalPlays} partidas · ${sum.wins} com ★ (${Math.round(100 * sum.wins / sum.totalPlays)}%)` : "";
+  const grid = document.getElementById("stats-grid");
+  grid.innerHTML = "";
+  const ids = Object.keys(sum.byLevel);
+  if (ids.length) {
+    const head = document.createElement("div");
+    head.className = "stat-row head";
+    head.innerHTML = `<span class="sr-name">fase</span><span>partidas</span><span>melhor ★</span><span>melhor / média</span>`;
+    grid.appendChild(head);
+  }
+  // Order by campaign order when known.
+  ids.sort((a, b) => LEVELS.findIndex((l) => l.id === a) - LEVELS.findIndex((l) => l.id === b));
+  for (const id of ids) {
+    const L = sum.byLevel[id];
+    const row = document.createElement("div");
+    row.className = "stat-row";
+    row.innerHTML = `<span class="sr-name">${L.name}</span><span>${L.plays}</span>` +
+      `<span class="sr-stars">${"★".repeat(L.bestStars)}${"☆".repeat(3 - L.bestStars)}</span>` +
+      `<span>${L.bestScore} / ${L.avgScore}</span>`;
+    grid.appendChild(row);
+  }
+}
+function openStats() { startScreen.classList.add("hidden"); buildStats(); statsScreen.classList.remove("hidden"); }
+document.getElementById("stats-btn").addEventListener("click", openStats);
+document.getElementById("stats-back").addEventListener("click", () => { statsScreen.classList.add("hidden"); startScreen.classList.remove("hidden"); });
+document.getElementById("stats-clear").addEventListener("click", () => { Telemetry.clear(); buildStats(); });
+
 const touchControls = document.getElementById("touch-controls");
 function bindTouch() {
   if (!touchControls) return;
@@ -748,6 +793,8 @@ function launch(g) {
   game = g;
   gameState = "playing";
   online = false;
+  humanSession = true;
+  trackRoundStart();
   startScreen.classList.add("hidden");
   pauseScreen.classList.add("hidden");
   resultScreen.classList.add("hidden");
@@ -831,6 +878,7 @@ function onlineLoop() {
 function showOnlineResult() {
   const r = (game && game.result) || Net.result;
   if (!r) return;
+  trackRoundEnd();
   document.getElementById("result-stars").innerHTML = [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
   document.getElementById("result-score").textContent = "Score: " + r.score;
   document.getElementById("result-stats").textContent = `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}`;
@@ -847,6 +895,8 @@ function onSnapshot(s) {
 
 function beginOnline() {
   online = true; _onlineEnded = false; running = false; // stop any offline rAF
+  humanSession = true; currentMode = "online"; currentLevelIndex = -1;
+  if (Net.lastSnapshot) Telemetry.track("round_start", { mode: "online", levelName: Net.lastSnapshot.levelName, players: Net.lastSnapshot.playerCount });
   startScreen.classList.add("hidden"); pauseScreen.classList.add("hidden"); resultScreen.classList.add("hidden");
   const os = document.getElementById("online-screen"); if (os) os.classList.add("hidden");
   if (actx && actx.state === "suspended") actx.resume().catch(() => {});
@@ -950,6 +1000,8 @@ document.getElementById("lobby-leave").addEventListener("click", () => { closeOn
 ctx.fillStyle = "#6ab04c";
 ctx.fillRect(0, 0, WORLD.w, WORLD.h);
 
+Telemetry.init({ endpoint: new URLSearchParams(location.search).get("telemetry") });
+
 if (location.search.includes("debug")) {
   const params = new URLSearchParams(location.search);
   if (params.has("seed")) { pendingSeed = parseInt(params.get("seed"), 10); Sim.seedRng(pendingSeed); }
@@ -974,6 +1026,7 @@ if (location.search.includes("debug")) {
       const level = levelId ? LEVELS.find((l) => l.id === levelId) : null;
       selectedDifficulty = players; selectedPlayers = 1;
       currentMode = level ? "campaign" : "quick"; currentLevelIndex = level ? LEVELS.indexOf(level) : -1;
+      humanSession = false; // headless: no telemetry
       sound.setMuted(true);
       game = createGame(1, level ? { level } : { difficulty: players });
       gameState = "playing";
@@ -985,6 +1038,7 @@ if (location.search.includes("debug")) {
       if (seed != null) pendingSeed = seed;
       selectedPlayers = count; selectedDifficulty = difficulty;
       currentMode = "quick"; currentLevelIndex = -1;
+      humanSession = false; // headless: no telemetry
       sound.setMuted(true);
       game = createGame(count, { difficulty });
       for (const p of game.players) p.device = { type: "bot" };

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,7 @@
       <button id="campaign-btn" class="big-btn" disabled>🗺️ Campanha</button>
       <button id="start-btn" class="big-btn secondary" disabled>Jogo rápido</button>
       <button id="online-btn" class="big-btn secondary">🌐 Jogar online</button>
+      <button id="stats-btn" class="big-btn secondary">📊 Estatísticas</button>
       <div class="controls">
         <strong>P1:</strong> WASD mover · SHIFT correr · E interagir · Q largar · P pausar
         <br />
@@ -72,6 +73,15 @@
       <p class="desc">Ganhe ★ pra desbloquear as próximas fases. Jogue sozinho ou com até 4 no mesmo teclado/controle (escolha no menu).</p>
       <div id="level-grid"></div>
       <button id="campaign-back" class="big-btn secondary">Voltar</button>
+    </div>
+
+    <!-- Local stats (playtest) -->
+    <div id="stats-screen" class="overlay hidden">
+      <h1>Estatísticas</h1>
+      <p id="stats-overall" class="desc"></p>
+      <div id="stats-grid"></div>
+      <button id="stats-clear" class="big-btn secondary">Limpar dados</button>
+      <button id="stats-back" class="big-btn secondary">Voltar</button>
     </div>
 
     <!-- Online lobby -->

--- a/web/style.css
+++ b/web/style.css
@@ -131,6 +131,14 @@ canvas#game {
 .online-label { color: #d9e8c8; font-size: 15px; display: block; margin: 4px 0; }
 .online-label select { font-size: 15px; padding: 5px 8px; border-radius: 6px; border: 2px solid #5b7a45; background: #2a3a1f; color: #fff; }
 
+#stats-grid { width: min(560px, 88vw); margin: 6px 0 12px; display: flex; flex-direction: column; gap: 6px; }
+.stat-row { display: grid; grid-template-columns: 1.4fr 0.7fr 1fr 1.1fr; gap: 8px; align-items: center; background: rgba(0,0,0,0.26); border-radius: 8px; padding: 8px 12px; font-size: 14px; }
+.stat-row.head { background: transparent; color: #9bb583; font-size: 12px; padding: 2px 12px; }
+.stat-row .sr-name { font-weight: bold; color: #f4ecd6; text-align: left; }
+.stat-row .sr-stars { color: #f7d774; letter-spacing: 1px; }
+#stats-overall { color: #d9e8c8; }
+#stats-grid:empty::after { content: "Sem partidas registradas ainda — jogue uma fase."; color: #9bb583; font-size: 14px; }
+
 #level-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/web/telemetry.js
+++ b/web/telemetry.js
@@ -1,0 +1,65 @@
+"use strict";
+/*
+ * Lightweight gameplay telemetry. Records round lifecycle events to a local
+ * ring buffer (localStorage) and, when an endpoint is configured, also beacons
+ * them out — so the same instrumentation powers a local "stats" view now and a
+ * real analytics backend once the game is deployed.
+ *
+ * No PII, no per-tick spam: a handful of events per round (start/end/unlock).
+ * Disabled cleanly when localStorage is unavailable.
+ */
+const KEY = "overgarden.telemetry";
+const MAX = 300; // ring buffer cap
+
+export const Telemetry = {
+  endpoint: null,
+  enabled: true,
+
+  init({ endpoint = null } = {}) { this.endpoint = endpoint; },
+
+  track(event, props = {}) {
+    if (!this.enabled) return;
+    const e = { event, ts: Date.now(), ...props };
+    this._store(e);
+    this._beacon(e);
+  },
+
+  _store(e) {
+    try {
+      const all = this.all();
+      all.push(e);
+      if (all.length > MAX) all.splice(0, all.length - MAX);
+      localStorage.setItem(KEY, JSON.stringify(all));
+    } catch (_) {}
+  },
+  _beacon(e) {
+    if (!this.endpoint) return;
+    try {
+      const body = JSON.stringify(e);
+      if (navigator.sendBeacon) navigator.sendBeacon(this.endpoint, body);
+      else fetch(this.endpoint, { method: "POST", body, keepalive: true, headers: { "Content-Type": "application/json" } }).catch(() => {});
+    } catch (_) {}
+  },
+
+  all() { try { return JSON.parse(localStorage.getItem(KEY)) || []; } catch (_) { return []; } },
+  clear() { try { localStorage.removeItem(KEY); } catch (_) {} },
+
+  // Aggregate round_end events into per-level + overall stats for the UI.
+  summary() {
+    const ends = this.all().filter((e) => e.event === "round_end");
+    const byLevel = {};
+    let totalPlays = 0, wins = 0;
+    for (const e of ends) {
+      const id = e.level || "—";
+      const L = byLevel[id] || (byLevel[id] = { name: e.levelName || id, plays: 0, bestScore: 0, bestStars: 0, sumScore: 0, starHist: [0, 0, 0, 0] });
+      L.plays++; totalPlays++;
+      L.sumScore += e.score || 0;
+      L.bestScore = Math.max(L.bestScore, e.score || 0);
+      L.bestStars = Math.max(L.bestStars, e.stars || 0);
+      L.starHist[e.stars || 0]++;
+      if ((e.stars || 0) >= 1) wins++;
+    }
+    for (const id in byLevel) byLevel[id].avgScore = Math.round(byLevel[id].sumScore / byLevel[id].plays);
+    return { totalPlays, wins, byLevel };
+  },
+};


### PR DESCRIPTION
## O que é (parte 1 do "2 e 3" — telemetria/playtest)

Instrumenta o jogo pra coletar métricas de rodada e expõe uma tela de **Estatísticas** local — a base pra afinar a curva com dados reais (e pra ligar num backend depois do deploy).

## Como funciona

- **`web/telemetry.js`**: `track(event, props)` grava num **ring buffer** em `localStorage` e, se houver endpoint (`?telemetry=URL`), também faz **beacon** — mesma instrumentação pra stats local agora e analytics depois.
- Eventos por rodada (sem spam por tick): **`round_start`** e **`round_end`** com fase, modo, jogadores, score, ★, entregues/perdidos.
- Instrumenta só os caminhos **humanos** (campanha/quick/online). O **headless (harness) fica gated** (`humanSession=false`) → e2e por-PR **intacto**.
- Tela **📊 Estatísticas** no menu: agrega por fase (partidas, melhor ★, melhor/média score) + "Limpar dados". É a ferramenta de playtest — dá pra ver a própria performance por fase.

## Testes

- e2e default **idêntico** (90/84) · teste de rede ok.
- Fluxo validado: jogar fase → `round_start`+`round_end` gravados → fase aparece nas estatísticas; **headless não grava** nada (screenshot no PR).

## Próximo

Parte 2 do pedido: **mais conteúdo** (chefes de fim de fase / loja+upgrades) — vem no próximo PR.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_