### PR TITLE
Conteúdo: chefe de fim de fase (pedido VIP)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,7 +69,7 @@ sozinho ou em co-op, com caos crescente.
 **Jogabilidade**
 - [x] **Co-op online** (netcode) — servidor WebSocket autoritativo + interpolação + drop-in/reconexão (`server/`, `web/net.js`; ver `docs/COOP_DESIGN.md`).
 - [ ] Loja entre fases (upgrades de estação) e economia.
-- [x] **Eventos/clima dinâmicos** durante a fase (chuva rega tudo, seca acelera murcha, "rush" de pedidos dourados com bônus) — opt-in por fase via `levels.json` (`events`), refletidos no servidor online. Faltam: chefes de fim de fase, fases temáticas por estação.
+- [x] **Eventos/clima dinâmicos** (chuva/seca/rush) + **chefe de fim de fase** (pedido VIP grande com recompensa multiplicada) — opt-in por fase via `levels.json` (`events`/`boss`), refletidos no online. Falta: fases temáticas por estação, loja/upgrades entre fases.
 
 **Engenharia**
 - [ ] **Decisão de engine**: Canvas puro vs. Phaser/Pixi vs. voltar ao Unity WebGL (reaproveitar assets/animações).

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -58,7 +58,7 @@ function serialize(st) {
     stations: st.stations.map((x) => ({ type: x.type, x: x.x, y: x.y, label: x.label, icon: x.icon })),
     players: st.players.map((p) => ({ index: p.index, color: p.color, x: Math.round(p.x * 10) / 10, y: Math.round(p.y * 10) / 10, facing: p.facing, moving: p.moving, holding: p.holding, heldSeed: p.heldSeed ? p.heldSeed.name : null, heldPlant: p.heldPlant ? p.heldPlant.name : null, stamina: Math.round(p.stamina), anim: Math.round(p.anim * 100) / 100, seedMenu: { open: p.seedMenu.open, index: p.seedMenu.index } })),
     plots: st.plots.map((pl) => ({ x: pl.x, y: pl.y, stage: pl.stage, progress: Math.round(pl.progress * 1000) / 1000, life: Math.round(pl.life * 1000) / 1000, wilt: Math.round(pl.wilt * 100) / 100, plant: pl.plant ? pl.plant.name : null })),
-    orders: st.orders.map((o) => ({ id: o.id, need: o.need, qty: o.qty, timeLeft: Math.round(o.timeLeft * 100) / 100, maxTime: o.maxTime, plant: o.plant.name })),
+    orders: st.orders.map((o) => ({ id: o.id, need: o.need, qty: o.qty, timeLeft: Math.round(o.timeLeft * 100) / 100, maxTime: o.maxTime, plant: o.plant.name, boss: o.boss || false })),
     events: st.events.slice(),
   };
 }

--- a/web/assets/levels.json
+++ b/web/assets/levels.json
@@ -63,9 +63,9 @@
       "difficulty": 1,
       "duration": 150,
       "stars": [
-        90,
-        180,
-        270
+        100,
+        200,
+        310
       ],
       "events": [
         "rain"
@@ -202,12 +202,18 @@
     {
       "id": "estufa",
       "name": "Estufa",
+      "boss": {
+        "at": 0.6,
+        "qty": 3,
+        "time": 50,
+        "rewardMult": 3
+      },
       "difficulty": 2,
       "duration": 150,
       "stars": [
-        130,
-        270,
-        410
+        50,
+        100,
+        150
       ],
       "events": [
         "rush",
@@ -282,12 +288,18 @@
     {
       "id": "mercado",
       "name": "Mercado",
+      "boss": {
+        "at": 0.55,
+        "qty": 3,
+        "time": 55,
+        "rewardMult": 3
+      },
       "difficulty": 3,
       "duration": 155,
       "stars": [
-        50,
-        110,
-        160
+        120,
+        240,
+        360
       ],
       "events": [
         "drought",
@@ -357,12 +369,18 @@
     {
       "id": "festival",
       "name": "Festival",
+      "boss": {
+        "at": 0.55,
+        "qty": 5,
+        "time": 60,
+        "rewardMult": 4
+      },
       "difficulty": 3,
       "duration": 170,
       "stars": [
-        110,
-        210,
-        330
+        120,
+        230,
+        360
       ],
       "events": [
         "rain",

--- a/web/game.js
+++ b/web/game.js
@@ -223,7 +223,7 @@ function trackRoundStart() {
 function trackRoundEnd() {
   if (!humanSession || !game || !game.result) return;
   const r = game.result;
-  Telemetry.track("round_end", { mode: currentMode, level: game.levelId || game.levelName, levelName: game.levelName, players: game.playerCount, score: r.score, stars: r.stars, delivered: r.delivered, expired: r.expired });
+  Telemetry.track("round_end", { mode: currentMode, level: game.levelId || game.levelName, levelName: game.levelName, players: game.playerCount, score: r.score, stars: r.stars, delivered: r.delivered, expired: r.expired, bossCleared: !!r.bossCleared });
 }
 
 function createGame(playerCount, { difficulty = 1, level = null } = {}) {
@@ -276,6 +276,7 @@ function finishRound() {
   document.getElementById("result-stats").textContent =
     (currentMode === "campaign" ? `${game.levelName} · ` : "") +
     `Entregues: ${r.delivered} · perdidos: ${r.expired}` +
+    (r.bossCleared ? " · 👑 chefe!" : "") +
     (r.stars < 3 ? ` · próxima ★ em ${r.goals[Math.min(r.stars, 2)]}` : " · máximo!");
   setResultButtons();
   resultScreen.classList.remove("hidden");
@@ -542,13 +543,14 @@ function drawOrders() {
   const y = 58;
   for (const o of game.orders) {
     const urg = o.timeLeft / o.maxTime;
-    const col = urg > 0.5 ? "#5fd35f" : urg > 0.25 ? "#f0c419" : "#e74c3c";
-    ctx.fillStyle = "rgba(20,30,16,0.82)"; roundRect(x, y, cw, ch, 8, true, false);
-    ctx.strokeStyle = col; ctx.lineWidth = 3; roundRect(x, y, cw, ch, 8, false, true);
+    const col = o.boss ? "#f7d774" : urg > 0.5 ? "#5fd35f" : urg > 0.25 ? "#f0c419" : "#e74c3c";
+    ctx.fillStyle = o.boss ? "rgba(60,46,12,0.9)" : "rgba(20,30,16,0.82)"; roundRect(x, y, cw, ch, 8, true, false);
+    ctx.strokeStyle = col; ctx.lineWidth = o.boss ? 4 : 3; roundRect(x, y, cw, ch, 8, false, true);
+    if (o.boss) { ctx.font = "14px sans-serif"; ctx.textAlign = "center"; ctx.fillText("👑", x + cw / 2, y - 4); }
     const m = o.plant.main;
     if (m) { const ih = 32, iw = ih * (m.w / m.h); drawFrame(m.sheet, m, x + cw / 2 - iw / 2, y + 7, iw, ih); }
-    ctx.fillStyle = "#fff"; ctx.font = "bold 14px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
-    ctx.fillText("x" + o.need, x + cw / 2, y + ch - 12);
+    ctx.fillStyle = o.boss ? "#f7d774" : "#fff"; ctx.font = "bold 14px Trebuchet MS, sans-serif"; ctx.textAlign = "center";
+    ctx.fillText((o.boss ? "CHEFE x" : "x") + o.need, x + cw / 2, y + ch - 12);
     bar(x + 8, y + ch - 7, cw - 16, 4, urg, col, "#333");
     x += cw + gap;
   }
@@ -881,7 +883,7 @@ function showOnlineResult() {
   trackRoundEnd();
   document.getElementById("result-stars").innerHTML = [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
   document.getElementById("result-score").textContent = "Score: " + r.score;
-  document.getElementById("result-stats").textContent = `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}`;
+  document.getElementById("result-stats").textContent = `Pedidos entregues: ${r.delivered} · perdidos: ${r.expired}` + (r.bossCleared ? " · 👑 chefe!" : "");
   document.getElementById("again-btn").classList.add("hidden"); // server rooms don't restart
   resultScreen.classList.remove("hidden");
 }

--- a/web/sim.js
+++ b/web/sim.js
@@ -118,10 +118,11 @@ export function createState({ playerCount = 1, difficulty = 1, seed = null, leve
     score: 0, paused: false, over: false, result: null,
     eventTypes: (L.events || []).filter((t) => EVENTS.defs[t]),
     eventTimer: EVENTS.interval * 0.55, weather: null,
+    boss: L.boss || null, bossSpawned: false,
     time: L.duration,
     orders: [], orderId: 1, orderSpawnTimer: 3,
     combo: 0, comboTimer: 0,
-    stats: { delivered: 0, expired: 0 },
+    stats: { delivered: 0, expired: 0, bossCleared: false },
     particles: [], floaters: [], shake: 0, anyMoving: false,
     players, plots, stations,
     events: [],
@@ -155,6 +156,20 @@ function decayMult(s) {
   return base * (s.weather && s.weather.type === "drought" ? EVENTS.defs.drought.decay : 1);
 }
 function rushMult(s) { return s.weather && s.weather.type === "rush" ? EVENTS.defs.rush.mult : 1; }
+// End-of-round "boss": one big VIP order of a noble crop, generous timer,
+// reward ×rewardMult. Data-driven per level via level.boss; spawns once when the
+// round is `at` fraction through. Flows through the normal delivery pipeline.
+function updateBoss(s) {
+  if (!s.boss || s.bossSpawned) return;
+  if (roundProgress(s) < (s.boss.at != null ? s.boss.at : 0.6)) return;
+  const pool = s.plantPool && s.plantPool.length ? s.plantPool : PLANTS;
+  const plant = (s.boss.plant && pool.find((p) => p.name === s.boss.plant)) || pool.reduce((a, b) => (b.rarity > a.rarity ? b : a), pool[0]);
+  const qty = s.boss.qty || 3, time = s.boss.time || 50;
+  s.orders.push({ plant, need: qty, qty, timeLeft: time, maxTime: time, id: s.orderId++, boss: true, rewardMult: s.boss.rewardMult || 3 });
+  s.bossSpawned = true;
+  spawnFloater(s, WORLD.w / 2, 150, "👑 Pedido do Chefe!", "#f7d774");
+  addShake(s, 6); ev(s, "ding");
+}
 function updateEvents(s, dt) {
   if (!s.eventTypes.length) return;
   if (s.weather) { s.weather.timeLeft -= dt; if (s.weather.timeLeft <= 0) s.weather = null; return; }
@@ -224,8 +239,9 @@ function completeOrder(s, o) {
   const tip = Math.round(base * 0.5 * (o.timeLeft / o.maxTime));
   s.combo++; s.comboTimer = ORDER.comboWindow;
   const mult = 1 + 0.1 * Math.min(s.combo - 1, 9);
-  const total = Math.round((base + tip) * mult * rushMult(s));
+  const total = Math.round((base + tip) * mult * rushMult(s) * (o.boss ? (o.rewardMult || 1) : 1));
   s.score += total; s.stats.delivered++;
+  if (o.boss) s.stats.bossCleared = true;
   const st = stationOf(s, "sales");
   spawnParticles(s, st.x, st.y - 16, { n: 20, color: "#f7d774", speed: 150 });
   spawnFloater(s, st.x, st.y - 34, "+" + total + (s.combo > 1 ? "  x" + s.combo : ""), "#f7d774");
@@ -361,7 +377,7 @@ function endRound(s) {
   s.over = true;
   const goals = starGoals(s), sc = s.score;
   const stars = sc >= goals[2] ? 3 : sc >= goals[1] ? 2 : sc >= goals[0] ? 1 : 0;
-  s.result = { score: sc, stars, goals, delivered: s.stats.delivered, expired: s.stats.expired };
+  s.result = { score: sc, stars, goals, delivered: s.stats.delivered, expired: s.stats.expired, bossCleared: s.stats.bossCleared };
 }
 
 // ---- main step -------------------------------------------------------------
@@ -372,6 +388,7 @@ export function step(s, intents, dt) {
   if (s.time <= 0) { s.time = 0; endRound(s); return s; }
   updateFX(s, dt);
   updateEvents(s, dt);
+  updateBoss(s);
   updateOrders(s, dt);
   let anyMoving = false;
   for (let i = 0; i < s.players.length; i++) {


### PR DESCRIPTION
## O que é (parte 2 do "2 e 3" — mais conteúdo)

Adiciona **chefe de fim de fase**: um "Pedido do Chefe" (VIP) grande que surge no fim da rodada, com prazo generoso e recompensa multiplicada. Reaproveita o pipeline de pedidos existente.

## Como funciona

- **Data-driven por fase** (`levels.json` → `boss: { at, qty, time, rewardMult, plant? }`). Surge **uma vez** quando a rodada está `at` do fim; pede `qty` de um cultivo nobre (o de maior raridade do pool, ou um nomeado). Recompensa ×`rewardMult`.
- Flui pelo **pipeline normal** de entrega/expiração; completar marca `bossCleared`. Floater "👑 Pedido do Chefe!" + shake ao surgir.
- **Card distinto** (dourado, 👑, "CHEFE x5"); resultado e **telemetria** registram `bossCleared`; o `boss` vai no snapshot → **online mostra o chefe igual**.
- **Default/quick/e2e não têm boss** → inalterados.

## Fases com chefe

| Fase | chefe |
|---|---|
| Estufa | ×3, +50s, recompensa ×3 |
| Mercado | ×3, +55s, recompensa ×3 |
| Festival | ×5, +60s, recompensa ×4 |

Metas de ★ recalibradas (o chefe muda o throughput; o bot conservador tem dificuldade de cumprir um pedido multi-unidade, então as metas das fases com chefe refletem isso).

## Testes

- e2e default **idêntico** (90/84) · teste de rede ok.
- Chefe surge e renderiza (Festival: Aubergine ×5, ×4 — screenshot no PR).

## Restante do "3"

Falta a **loja/upgrades entre fases** (economia + persistência) — sistema maior, fica como próximo passo se quiser.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_