### PR TITLE
Conteúdo: loja + upgrades (meta-progressão)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,7 +68,7 @@ sozinho ou em co-op, com caos crescente.
 
 **Jogabilidade**
 - [x] **Co-op online** (netcode) — servidor WebSocket autoritativo + interpolação + drop-in/reconexão (`server/`, `web/net.js`; ver `docs/COOP_DESIGN.md`).
-- [ ] Loja entre fases (upgrades de estação) e economia.
+- [x] **Loja + upgrades** (`web/shop.js`): moedas por rodada + 4 upgrades persistentes (velocidade/murcha/crescimento/tempo) que modulam o sim no offline (campanha/quick). Online segue vanilla.
 - [x] **Eventos/clima dinâmicos** (chuva/seca/rush) + **chefe de fim de fase** (pedido VIP grande com recompensa multiplicada) — opt-in por fase via `levels.json` (`events`/`boss`), refletidos no online. Falta: fases temáticas por estação, loja/upgrades entre fases.
 
 **Engenharia**

--- a/web/game.js
+++ b/web/game.js
@@ -10,6 +10,7 @@
 import * as Sim from "./sim.js";
 import { Net } from "./net.js";
 import { Telemetry } from "./telemetry.js";
+import { Shop, UPGRADES } from "./shop.js";
 
 const { HOLD, STAGE, WORLD, TUNE, ROUND, ORDER, COOP } = Sim;
 
@@ -226,8 +227,8 @@ function trackRoundEnd() {
   Telemetry.track("round_end", { mode: currentMode, level: game.levelId || game.levelName, levelName: game.levelName, players: game.playerCount, score: r.score, stars: r.stars, delivered: r.delivered, expired: r.expired, bossCleared: !!r.bossCleared });
 }
 
-function createGame(playerCount, { difficulty = 1, level = null } = {}) {
-  const s = Sim.createState({ playerCount, difficulty, seed: pendingSeed, level });
+function createGame(playerCount, { difficulty = 1, level = null, mods = null } = {}) {
+  const s = Sim.createState({ playerCount, difficulty, seed: pendingSeed, level, mods });
   pendingSeed = null;
   const devices = assignDevices(playerCount);
   s.players.forEach((p, i) => { p.device = devices[i]; });
@@ -270,6 +271,8 @@ function finishRound() {
   const r = game.result;
   trackRoundEnd();
   if (currentMode === "campaign" && currentLevelIndex >= 0) saveStars(LEVELS[currentLevelIndex].id, r.stars);
+  const coinsEarned = humanSession ? Shop.reward(r) : 0;
+  if (coinsEarned) Shop.earn(coinsEarned);
   document.getElementById("result-stars").innerHTML =
     [0, 1, 2].map((i) => `<span class="${i < r.stars ? "on" : "off"}">★</span>`).join("");
   document.getElementById("result-score").textContent = "Score: " + r.score;
@@ -277,6 +280,7 @@ function finishRound() {
     (currentMode === "campaign" ? `${game.levelName} · ` : "") +
     `Entregues: ${r.delivered} · perdidos: ${r.expired}` +
     (r.bossCleared ? " · 👑 chefe!" : "") +
+    (coinsEarned ? ` · +${coinsEarned} 🪙` : "") +
     (r.stars < 3 ? ` · próxima ★ em ${r.goals[Math.min(r.stars, 2)]}` : " · máximo!");
   setResultButtons();
   resultScreen.classList.remove("hidden");
@@ -742,6 +746,29 @@ document.getElementById("stats-btn").addEventListener("click", openStats);
 document.getElementById("stats-back").addEventListener("click", () => { statsScreen.classList.add("hidden"); startScreen.classList.remove("hidden"); });
 document.getElementById("stats-clear").addEventListener("click", () => { Telemetry.clear(); buildStats(); });
 
+// ---- Shop / upgrades ----
+const shopScreen = document.getElementById("shop-screen");
+function buildShop() {
+  document.getElementById("shop-coins").textContent = `🪙 ${Shop.coins()}`;
+  const grid = document.getElementById("shop-grid");
+  grid.innerHTML = "";
+  for (const u of UPGRADES) {
+    const lvl = Shop.level(u.id), cost = Shop.costOf(u.id), maxed = lvl >= u.max;
+    const card = document.createElement("div");
+    card.className = "shop-card" + (maxed ? " maxed" : "");
+    const pips = "●".repeat(lvl) + "○".repeat(u.max - lvl);
+    const btn = maxed ? `<button class="sc-buy" disabled>MÁX</button>`
+      : `<button class="sc-buy" data-id="${u.id}" ${Shop.coins() < cost ? "disabled" : ""}>🪙 ${cost}</button>`;
+    card.innerHTML = `<div class="sc-icon">${u.icon}</div>` +
+      `<div><div class="sc-name">${u.name}</div><div class="sc-desc">${u.desc}</div><div class="sc-pips">${pips}</div></div>${btn}`;
+    grid.appendChild(card);
+  }
+  grid.querySelectorAll(".sc-buy[data-id]").forEach((b) => b.addEventListener("click", () => { if (Shop.buy(b.dataset.id)) buildShop(); }));
+}
+function openShop() { startScreen.classList.add("hidden"); buildShop(); shopScreen.classList.remove("hidden"); }
+document.getElementById("shop-btn").addEventListener("click", openShop);
+document.getElementById("shop-back").addEventListener("click", () => { shopScreen.classList.add("hidden"); startScreen.classList.remove("hidden"); });
+
 const touchControls = document.getElementById("touch-controls");
 function bindTouch() {
   if (!touchControls) return;
@@ -815,13 +842,13 @@ function launch(g) {
 function startGame() {
   if (!ASSETS.atlas) return;
   currentMode = "quick"; currentLevelIndex = -1;
-  launch(createGame(selectedPlayers, { difficulty: selectedDifficulty }));
+  launch(createGame(selectedPlayers, { difficulty: selectedDifficulty, mods: Shop.mods() }));
 }
 
 function startLevel(i) {
   if (!ASSETS.atlas || !LEVELS[i]) return;
   currentMode = "campaign"; currentLevelIndex = i;
-  launch(createGame(selectedPlayers, { level: LEVELS[i] }));
+  launch(createGame(selectedPlayers, { level: LEVELS[i], mods: Shop.mods() }));
 }
 
 function quitToMenu() {

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,7 @@
       <button id="campaign-btn" class="big-btn" disabled>🗺️ Campanha</button>
       <button id="start-btn" class="big-btn secondary" disabled>Jogo rápido</button>
       <button id="online-btn" class="big-btn secondary">🌐 Jogar online</button>
+      <button id="shop-btn" class="big-btn secondary">🛒 Loja</button>
       <button id="stats-btn" class="big-btn secondary">📊 Estatísticas</button>
       <div class="controls">
         <strong>P1:</strong> WASD mover · SHIFT correr · E interagir · Q largar · P pausar
@@ -73,6 +74,15 @@
       <p class="desc">Ganhe ★ pra desbloquear as próximas fases. Jogue sozinho ou com até 4 no mesmo teclado/controle (escolha no menu).</p>
       <div id="level-grid"></div>
       <button id="campaign-back" class="big-btn secondary">Voltar</button>
+    </div>
+
+    <!-- Shop / upgrades -->
+    <div id="shop-screen" class="overlay hidden">
+      <h1>Loja</h1>
+      <p id="shop-coins" class="desc">🪙 0</p>
+      <p class="desc">Ganhe moedas jogando. Upgrades valem em campanha e jogo rápido.</p>
+      <div id="shop-grid"></div>
+      <button id="shop-back" class="big-btn secondary">Voltar</button>
     </div>
 
     <!-- Local stats (playtest) -->

--- a/web/shop.js
+++ b/web/shop.js
@@ -1,0 +1,51 @@
+"use strict";
+/*
+ * Shop / meta-progression. Coins are earned per offline round and spent on
+ * persistent upgrades that tweak the simulation (move speed, wilt rate, growth
+ * rate, round time). State lives in localStorage.
+ *
+ * Upgrades apply to offline play (campaign/quick) only — online rounds run on
+ * the authoritative server with vanilla tuning for fairness.
+ */
+const KEY = "overgarden.shop";
+
+export const UPGRADES = [
+  { id: "boots", name: "Botas Velozes", icon: "👟", desc: "+8% de velocidade por nível", max: 3, cost: [120, 260, 440] },
+  { id: "fertilizer", name: "Adubo", icon: "🌿", desc: "Plantas murcham ~12% mais devagar", max: 3, cost: [150, 320, 520] },
+  { id: "greenhouse", name: "Estufa Rápida", icon: "🌱", desc: "Crescimento ~8% mais rápido", max: 3, cost: [180, 360, 600] },
+  { id: "clock", name: "Relógio Extra", icon: "⏱️", desc: "+8s de rodada por nível", max: 2, cost: [220, 420] },
+];
+
+export const Shop = {
+  load() { try { return JSON.parse(localStorage.getItem(KEY)) || { coins: 0, levels: {} }; } catch (_) { return { coins: 0, levels: {} }; } },
+  save(s) { try { localStorage.setItem(KEY, JSON.stringify(s)); } catch (_) {} },
+  coins() { return this.load().coins || 0; },
+  level(id) { return this.load().levels[id] || 0; },
+  costOf(id) { const u = UPGRADES.find((x) => x.id === id); const lvl = this.level(id); return lvl >= u.max ? null : u.cost[lvl]; },
+
+  // Coins earned for a finished round.
+  reward({ stars = 0, score = 0 } = {}) { return stars * 15 + Math.floor(score / 15); },
+  earn(n) { const s = this.load(); s.coins = (s.coins || 0) + Math.max(0, Math.round(n)); this.save(s); return s.coins; },
+  buy(id) {
+    const u = UPGRADES.find((x) => x.id === id);
+    const s = this.load();
+    const lvl = s.levels[id] || 0;
+    if (!u || lvl >= u.max) return false;
+    const cost = u.cost[lvl];
+    if ((s.coins || 0) < cost) return false;
+    s.coins -= cost; s.levels[id] = lvl + 1; this.save(s);
+    return true;
+  },
+  reset() { this.save({ coins: 0, levels: {} }); },
+
+  // Combined simulation modifiers from owned upgrades.
+  mods() {
+    const L = this.load().levels || {};
+    return {
+      speedMult: 1 + 0.08 * (L.boots || 0),
+      decayMult: 1 - 0.12 * (L.fertilizer || 0),
+      growthMult: 1 - 0.08 * (L.greenhouse || 0),
+      bonusTime: 8 * (L.clock || 0),
+    };
+  },
+};

--- a/web/sim.js
+++ b/web/sim.js
@@ -92,8 +92,10 @@ export function defaultLevel() {
   };
 }
 
-export function createState({ playerCount = 1, difficulty = 1, seed = null, level = null } = {}) {
+export function createState({ playerCount = 1, difficulty = 1, seed = null, level = null, mods = null } = {}) {
   const L = level || defaultLevel();
+  const M = mods || { speedMult: 1, decayMult: 1, growthMult: 1, bonusTime: 0 };
+  const duration = L.duration + (M.bonusTime || 0);
   playerCount = Math.max(1, Math.min(4, playerCount));
   difficulty = Math.max(1, Math.min(4, L.difficulty != null ? L.difficulty : difficulty));
   const plots = L.plots.map((p) => ({ x: p.x, y: p.y, stage: STAGE.VIRGIN, plant: null, progress: 0, life: 1, wilt: 0 }));
@@ -112,14 +114,14 @@ export function createState({ playerCount = 1, difficulty = 1, seed = null, leve
   }
   return {
     _rng: seed != null ? makeRng(seed) : null,
-    mult: DIFFICULTY_MULT[difficulty - 1], difficulty, playerCount,
-    levelId: L.id, levelName: L.name, duration: L.duration, starsBase: L.stars.slice(),
+    mult: DIFFICULTY_MULT[difficulty - 1], difficulty, playerCount, mods: M,
+    levelId: L.id, levelName: L.name, duration, starsBase: L.stars.slice(),
     plantPool: pool.length ? pool : PLANTS.slice(),
     score: 0, paused: false, over: false, result: null,
     eventTypes: (L.events || []).filter((t) => EVENTS.defs[t]),
     eventTimer: EVENTS.interval * 0.55, weather: null,
     boss: L.boss || null, bossSpawned: false,
-    time: L.duration,
+    time: duration,
     orders: [], orderId: 1, orderSpawnTimer: 3,
     combo: 0, comboTimer: 0,
     stats: { delivered: 0, expired: 0, bossCleared: false },
@@ -149,11 +151,11 @@ export function nearestPlot(s, p) {
   for (const pl of s.plots) { const d = dist(p.x, p.y, pl.x, pl.y); if (d < bd) { bd = d; best = pl; } }
   return best;
 }
-function growthTime(s, plot) { return TUNE.growthBase * plot.plant.rarity * s.mult; }
+function growthTime(s, plot) { return TUNE.growthBase * plot.plant.rarity * s.mult * (s.mods.growthMult || 1); }
 function lifeTime(s, plot) { return TUNE.lifeBase * plot.plant.rarity * s.mult; }
 function decayMult(s) {
   const base = lerp(TUNE.decayRampMin, TUNE.decayRampMax, roundProgress(s));
-  return base * (s.weather && s.weather.type === "drought" ? EVENTS.defs.drought.decay : 1);
+  return base * (s.weather && s.weather.type === "drought" ? EVENTS.defs.drought.decay : 1) * (s.mods.decayMult || 1);
 }
 function rushMult(s) { return s.weather && s.weather.type === "rush" ? EVENTS.defs.rush.mult : 1; }
 // End-of-round "boss": one big VIP order of a noble crop, generous timer,
@@ -343,7 +345,7 @@ function updatePlayer(s, p, intent, dt) {
     const len = Math.hypot(dx, dy); dx /= len; dy /= len;
     if (Math.abs(dx) > Math.abs(dy)) p.facing = dx < 0 ? "left" : "right";
     else p.facing = dy < 0 ? "up" : "down";
-    const sp = p.speed * analogMag;
+    const sp = p.speed * analogMag * (s.mods.speedMult || 1);
     p.x += dx * sp * dt; p.y += dy * sp * dt; p.anim += dt * (running ? 12 : 8);
   } else { p.anim += dt * 3; }
   p.x = Math.max(28, Math.min(WORLD.w - 28, p.x));

--- a/web/style.css
+++ b/web/style.css
@@ -139,6 +139,17 @@ canvas#game {
 #stats-overall { color: #d9e8c8; }
 #stats-grid:empty::after { content: "Sem partidas registradas ainda — jogue uma fase."; color: #9bb583; font-size: 14px; }
 
+#shop-coins { color: #f7d774; font-weight: bold; font-size: 20px; }
+#shop-grid { width: min(560px, 88vw); margin: 6px 0 12px; display: flex; flex-direction: column; gap: 8px; }
+.shop-card { display: grid; grid-template-columns: 40px 1fr auto; gap: 10px; align-items: center; background: rgba(0,0,0,0.28); border: 2px solid #5b7a45; border-radius: 10px; padding: 10px 12px; }
+.shop-card .sc-icon { font-size: 26px; text-align: center; }
+.shop-card .sc-name { font-weight: bold; color: #f4ecd6; text-align: left; }
+.shop-card .sc-desc { font-size: 12px; color: #9bb583; text-align: left; }
+.shop-card .sc-pips { letter-spacing: 2px; color: #f7d774; font-size: 13px; }
+.shop-card .sc-buy { padding: 8px 12px; border-radius: 8px; border: none; background: #6ab04c; color: #10210a; font-weight: bold; cursor: pointer; min-width: 92px; }
+.shop-card .sc-buy:disabled { background: #44503c; color: #8a9580; cursor: default; }
+.shop-card.maxed { opacity: 0.7; }
+
 #level-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
## O que é (fecha o "3" — mais conteúdo)

Meta-progressão: **moedas** ganhas por rodada e uma **loja de upgrades** persistentes que modulam o jogo no offline.

## Como funciona

- **`web/shop.js`**: moedas (`★·15 + score/15`) e 4 upgrades em localStorage. `Shop.mods()` deriva modificadores do sim.
- **Upgrades** (com níveis):
  - 👟 **Botas Velozes** — +8% velocidade /nível (×3)
  - 🌿 **Adubo** — murcha ~12% mais devagar /nível (×3)
  - 🌱 **Estufa Rápida** — crescimento ~8% mais rápido /nível (×3)
  - ⏱️ **Relógio Extra** — +8s de rodada /nível (×2)
- **`sim.js`**: `createState({ mods })` aplica em velocidade do jogador, `growthTime`, `decayMult` e duração. **Sem mods (headless/online) → nada muda.**
- **`game.js`**: campanha/quick passam `Shop.mods()`; o resultado credita moedas (`+N 🪙`); tela **🛒 Loja** com cartões (nível em pips, custo, comprar). **Online segue vanilla** (servidor autoritativo, tuning padrão).

## Testes

- e2e default **idêntico** (90/84 — mods identidade no headless) · teste de rede ok.
- Fluxo validado: ganhar moedas (3★ → 65 🪙), comprar Relógio, e o upgrade refletir no sim (rodada vira **158s**). Screenshot da loja no PR.

## Estado do roadmap

Com isso, **2 e 3 estão completos**: telemetria + (eventos, chefes, loja). Aberto pra próximas frentes: **deploy do servidor** (pra online de verdade) ou **fases temáticas / mais upgrades**.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_