### PR TITLE
Lobby polish + backlog versionado (PR A)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,45 @@
+# Overgarden — Backlog de execução
+
+Plano de trabalho desta leva (lobby polish · áudio/FX · fases temáticas · novos
+upgrades). Cada item vira um PR coeso; o e2e por-PR e o teste de rede devem
+ficar verdes, e o nível default (usado pelo harness) tem que continuar idêntico.
+
+Legenda: ✅ feito · 🚧 em andamento · ⬜ a fazer.
+
+## PR A — Lobby polish ✅
+Resolver as arestas da UI online sem mexer no sim.
+- ✅ Seletor de nº de jogadores na própria tela Online (sincronizado com o menu).
+- ✅ Botão **Copiar código** (clipboard + fallback `navigator.share`).
+- ✅ Lista de slots no lobby ("P1 (você) / P2 / vazio") com cores.
+- ✅ Mensagem de erro de conexão ("não foi possível conectar ao servidor").
+
+## PR B — Áudio + FX ⬜
+Tudo client-side (render/áudio), sim intacto.
+- ⬜ Slider de volume (hoje só mudo) + persistência.
+- ⬜ Jingles de evento (chuva/seca/rush/chefe) e fanfarra de pedido completo (WebAudio).
+- ⬜ Cliques de UI.
+- ⬜ FX por evento: chuva caindo, brilho dourado (rush/chefe), shimmer de seca.
+- ⬜ Animação de revelação de estrelas no resultado.
+
+## PR C — Fases temáticas ⬜
+- ⬜ Campo `theme` por fase em `levels.json` (tint de fundo + rótulo); render aplica.
+- ⬜ `theme` no estado + snapshot (online mostra igual).
+- ⬜ 1–2 fases novas autoradas; recalibrar metas se mudarem throughput.
+- ⬜ (Opcional) mecânica temática leve (ex.: feira = mais pedidos).
+
+## PR D — Novos upgrades + UX ⬜
+- ⬜ Upgrades novos com hook no sim: Regador Duplo (rega canteiro vizinho),
+  Viveiro (começa com canteiros tratados), Comerciante (combo dura mais).
+- ⬜ Glifos de controle nas dicas de interação.
+- ⬜ Recalibrar metas das fases afetadas.
+
+## Princípios
+- Nível **default** sem features opt-in → harness/e2e por-PR inalterado (90/84).
+- **Online vanilla**: upgrades/temas cosméticos não dão vantagem competitiva no servidor.
+- Cada PR: validar `node tests/e2e/run.mjs` (default), `node tests/net/online.mjs`
+  e, quando mexer em fases, `node tests/e2e/levels.mjs`.
+
+## Fora do escopo desta leva (próximas)
+- Deploy do servidor (online "de verdade" fora da rede local).
+- Acessibilidade (daltonismo, remapear teclas, tamanho de texto).
+- Multiplayer local no celular; chat/emotes no lobby; host kick/migration.

--- a/web/game.js
+++ b/web/game.js
@@ -678,7 +678,15 @@ function bindChoiceGroup(selector, attr, setter) {
     });
   });
 }
-bindChoiceGroup(".count-btn", "count", (v) => { selectedPlayers = v; const cc = document.getElementById("create-count"); if (cc) cc.textContent = v; });
+// Player count is selectable on both the start screen and the online screen;
+// keep them in sync.
+function setCount(v) {
+  selectedPlayers = v;
+  const cc = document.getElementById("create-count"); if (cc) cc.textContent = v;
+  document.querySelectorAll(".count-btn, .ocount-btn").forEach((b) => b.classList.toggle("selected", parseInt(b.dataset.count, 10) === v));
+}
+document.querySelectorAll(".count-btn, .ocount-btn").forEach((b) => b.addEventListener("click", () => setCount(parseInt(b.dataset.count, 10))));
+setCount(1);
 bindChoiceGroup(".diff-btn", "diff", (v) => { selectedDifficulty = v; });
 
 startBtn.addEventListener("click", startGame);
@@ -968,13 +976,27 @@ function showOnlineScreen(show) {
   onlineScreen.classList.toggle("hidden", !show);
   if (show) { populateLevelSelect(); onlineSetup.classList.remove("hidden"); onlineLobby.classList.add("hidden"); onlineError.textContent = ""; }
 }
+function renderLobbySlots() {
+  const wrap = document.getElementById("lobby-slots");
+  wrap.innerHTML = "";
+  const occupied = Net.slots || [];
+  for (let i = 0; i < Net.count; i++) {
+    const filled = occupied.includes(i);
+    const chip = document.createElement("div");
+    chip.className = "slot-chip " + (filled ? "filled" : "empty") + (i === Net.slot ? " you" : "");
+    if (filled) chip.style.background = Sim.PLAYER_COLORS[i];
+    chip.textContent = "P" + (i + 1) + (i === Net.slot ? " (você)" : filled ? "" : " · vazio");
+    wrap.appendChild(chip);
+  }
+}
 function showLobbyView() {
   onlineSetup.classList.add("hidden"); onlineLobby.classList.remove("hidden");
   document.getElementById("room-code").textContent = Net.room || "----";
   document.getElementById("lobby-start").classList.toggle("hidden", !Net.host);
   document.getElementById("lobby-wait").classList.toggle("hidden", Net.host);
+  renderLobbySlots();
   document.getElementById("lobby-players").textContent =
-    `${Net.levelName ? "Fase: " + Net.levelName + " · " : ""}Jogadores na sala: ${Net.slots ? Net.slots.length : 1} / ${Net.count}`;
+    `${Net.levelName ? "Fase: " + Net.levelName + " · " : ""}${Net.slots ? Net.slots.length : 1} / ${Net.count} na sala`;
 }
 function closeOnline() {
   online = false;
@@ -1019,6 +1041,15 @@ document.getElementById("join-room").addEventListener("click", () => {
   const code = document.getElementById("join-code").value.trim().toUpperCase();
   if (code.length < 4) { onlineError.textContent = "digite o código (4 letras)"; return; }
   connectThen(() => Net.join(code));
+});
+document.getElementById("copy-code").addEventListener("click", async () => {
+  const code = Net.room || "";
+  try {
+    if (navigator.clipboard) await navigator.clipboard.writeText(code);
+    else if (navigator.share) await navigator.share({ text: code });
+  } catch (_) {}
+  const b = document.getElementById("copy-code"), prev = b.textContent;
+  b.textContent = "Copiado!"; setTimeout(() => { b.textContent = prev; }, 1200);
 });
 document.getElementById("lobby-start").addEventListener("click", () => Net.start());
 document.getElementById("lobby-leave").addEventListener("click", () => { closeOnline(); showOnlineScreen(false); startScreen.classList.remove("hidden"); });

--- a/web/index.html
+++ b/web/index.html
@@ -99,6 +99,14 @@
       <h1>Online</h1>
       <div id="online-setup">
         <p class="desc">Joguem juntos na mesma fazenda. O host cria a sala e compartilha o código; os outros entram (celular funciona).</p>
+        <div class="choice-row">Jogadores:
+          <span class="choices">
+            <button class="ocount-btn" data-count="1">1</button>
+            <button class="ocount-btn" data-count="2">2</button>
+            <button class="ocount-btn" data-count="3">3</button>
+            <button class="ocount-btn" data-count="4">4</button>
+          </span>
+        </div>
         <label class="online-label">Fase: <select id="online-level"></select></label>
         <button id="create-room" class="big-btn">Criar sala (<span id="create-count">1</span> jog.)</button>
         <div class="choices">
@@ -110,7 +118,8 @@
       </div>
       <div id="online-lobby" class="hidden">
         <p class="desc">Compartilhe o código:</p>
-        <div id="room-code">----</div>
+        <div class="code-row"><div id="room-code">----</div><button id="copy-code" class="copy-btn">Copiar</button></div>
+        <div id="lobby-slots"></div>
         <p id="lobby-players" class="controls">Jogadores: 1</p>
         <button id="lobby-start" class="big-btn">Começar</button>
         <p id="lobby-wait" class="controls hidden">Aguardando o host começar…</p>

--- a/web/style.css
+++ b/web/style.css
@@ -128,6 +128,17 @@ canvas#game {
   color: #fff;
 }
 .online-error { color: #ff8a7a; min-height: 18px; font-weight: bold; }
+.choice-row { color: #d9e8c8; font-size: 15px; margin: 4px 0; display: flex; align-items: center; gap: 8px; justify-content: center; }
+.ocount-btn { min-width: 38px; padding: 6px 10px; border-radius: 6px; border: 2px solid #5b7a45; background: #2a3a1f; color: #fff; cursor: pointer; font-weight: bold; }
+.ocount-btn.selected { background: #6ab04c; color: #10210a; border-color: #8fd16a; }
+.code-row { display: flex; align-items: center; gap: 10px; justify-content: center; }
+.copy-btn { padding: 8px 14px; border-radius: 8px; border: 2px solid #5b7a45; background: #2a3a1f; color: #f4ecd6; cursor: pointer; font-weight: bold; }
+.copy-btn:hover { border-color: #8fd16a; }
+#lobby-slots { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; margin: 8px 0; }
+.slot-chip { padding: 6px 12px; border-radius: 16px; border: 2px solid #5b7a45; font-weight: bold; font-size: 13px; color: #cdd9c0; background: rgba(0,0,0,0.25); }
+.slot-chip.filled { color: #10210a; }
+.slot-chip.you { outline: 2px solid #fff; }
+.slot-chip.empty { opacity: 0.5; border-style: dashed; }
 .online-label { color: #d9e8c8; font-size: 15px; display: block; margin: 4px 0; }
 .online-label select { font-size: 15px; padding: 5px 8px; border-radius: 6px; border: 2px solid #5b7a45; background: #2a3a1f; color: #fff; }
 


### PR DESCRIPTION
## PR A — Lobby polish + backlog versionado

Primeiro pacote da leva planejada. Inclui o **plano completo** em `docs/BACKLOG.md` (lobby · áudio/FX · fases temáticas · upgrades novos) e resolve as arestas da UI de lobby — **sem tocar no sim**.

### Lobby
- **Seletor de nº de jogadores na própria tela Online**, sincronizado com o do menu (antes só dava pra escolher no menu, fácil de não perceber).
- Botão **Copiar** o código da sala (clipboard + fallback `navigator.share`).
- **Chips de slot** no lobby: `P1 (você)` destacado, `P2`… com a cor de cada jogador; vazios tracejados.
- Linha de fase + contagem (`Fase: Quintal · 2/2 na sala`).

### Testes
- e2e default **idêntico** · teste de rede ok · lobby de 2 jogadores renderiza os slots (screenshot no PR).

Próximos PRs (já no backlog): **B áudio/FX**, **C fases temáticas**, **D upgrades novos**.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_