### PR TITLE
Fases temáticas + fase nova (PR C)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,11 +21,12 @@ Client-side (render/áudio); sim só ganhou rótulos de cue (gameplay-neutro).
 - ✅ FX por evento: chuva caindo + faíscas douradas no rush; tint pulsante por clima.
 - ✅ Animação de revelação de estrelas no resultado (CSS).
 
-## PR C — Fases temáticas ⬜
-- ⬜ Campo `theme` por fase em `levels.json` (tint de fundo + rótulo); render aplica.
-- ⬜ `theme` no estado + snapshot (online mostra igual).
-- ⬜ 1–2 fases novas autoradas; recalibrar metas se mudarem throughput.
-- ⬜ (Opcional) mecânica temática leve (ex.: feira = mais pedidos).
+## PR C — Fases temáticas ✅
+- ✅ `theme` por fase (spring/summer/autumn/night): cor de chão + overlay de mood; "default" = visual original (e2e intacto).
+- ✅ `theme` no estado + snapshot (online mostra o mesmo clima).
+- ✅ Fase nova: **Pomar Noturno** (night, 7 canteiros, diff 3, rain+rush, chefe).
+- ✅ Mercado: estações normalizadas (cantos extremos quebravam bot e fluidez); Estufa: só rush (seca+chefe junto craterava).
+- ✅ Metas em **curva monotônica à mão** (bot subrepresenta fases de muitos canteiros; ★1 verificado alcançável pelo bot como piso de "campanha completável").
 
 ## PR D — Novos upgrades + UX ⬜
 - ⬜ Upgrades novos com hook no sim: Regador Duplo (rega canteiro vizinho),

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -54,7 +54,7 @@ function serialize(st) {
   return {
     time: st.time, score: st.score, combo: st.combo, over: st.over, result: st.result,
     goals: Sim.starGoals(st), playerCount: st.playerCount, weather: st.weather,
-    levelName: st.levelName, plantPool: st.plantPool.map((p) => p.name),
+    levelName: st.levelName, theme: st.theme, plantPool: st.plantPool.map((p) => p.name),
     stations: st.stations.map((x) => ({ type: x.type, x: x.x, y: x.y, label: x.label, icon: x.icon })),
     players: st.players.map((p) => ({ index: p.index, color: p.color, x: Math.round(p.x * 10) / 10, y: Math.round(p.y * 10) / 10, facing: p.facing, moving: p.moving, holding: p.holding, heldSeed: p.heldSeed ? p.heldSeed.name : null, heldPlant: p.heldPlant ? p.heldPlant.name : null, stamina: Math.round(p.stamina), anim: Math.round(p.anim * 100) / 100, seedMenu: { open: p.seedMenu.open, index: p.seedMenu.index } })),
     plots: st.plots.map((pl) => ({ x: pl.x, y: pl.y, stage: pl.stage, progress: Math.round(pl.progress * 1000) / 1000, life: Math.round(pl.life * 1000) / 1000, wilt: Math.round(pl.wilt * 100) / 100, plant: pl.plant ? pl.plant.name : null })),

--- a/web/assets/levels.json
+++ b/web/assets/levels.json
@@ -6,9 +6,9 @@
       "difficulty": 1,
       "duration": 120,
       "stars": [
-        90,
-        180,
-        280
+        70,
+        150,
+        260
       ],
       "events": [],
       "plots": [
@@ -55,7 +55,8 @@
         "Carrot",
         "Potato",
         "Tomato"
-      ]
+      ],
+      "theme": "spring"
     },
     {
       "id": "fazenda",
@@ -63,9 +64,9 @@
       "difficulty": 1,
       "duration": 150,
       "stars": [
-        100,
-        200,
-        310
+        90,
+        190,
+        300
       ],
       "events": [
         "rain"
@@ -124,7 +125,8 @@
         "Tomato",
         "Corn",
         "SuspeciousLemon"
-      ]
+      ],
+      "theme": "spring"
     },
     {
       "id": "horta-dupla",
@@ -132,9 +134,9 @@
       "difficulty": 2,
       "duration": 160,
       "stars": [
-        120,
-        250,
-        380
+        110,
+        230,
+        360
       ],
       "events": [
         "rain",
@@ -197,7 +199,8 @@
         "Aubergine",
         "Pepper",
         "GrapeTomato"
-      ]
+      ],
+      "theme": "summer"
     },
     {
       "id": "estufa",
@@ -211,13 +214,12 @@
       "difficulty": 2,
       "duration": 150,
       "stars": [
-        50,
-        100,
-        150
+        130,
+        270,
+        420
       ],
       "events": [
-        "rush",
-        "drought"
+        "rush"
       ],
       "plots": [
         {
@@ -283,7 +285,8 @@
         "GrapeTomato",
         "Pepper",
         "Sweetsop"
-      ]
+      ],
+      "theme": "summer"
     },
     {
       "id": "mercado",
@@ -298,8 +301,8 @@
       "duration": 155,
       "stars": [
         120,
-        240,
-        360
+        250,
+        390
       ],
       "events": [
         "drought",
@@ -334,23 +337,23 @@
       "stations": [
         {
           "type": "tool",
-          "x": 84,
-          "y": 200
+          "x": 92,
+          "y": 250
         },
         {
           "type": "seed",
-          "x": 84,
-          "y": 470
+          "x": 92,
+          "y": 420
         },
         {
           "type": "water",
-          "x": 876,
-          "y": 200
+          "x": 868,
+          "y": 320
         },
         {
           "type": "sales",
-          "x": 876,
-          "y": 470
+          "x": 480,
+          "y": 548
         }
       ],
       "plantPool": [
@@ -364,7 +367,8 @@
         "GrapeTomato",
         "Pepper",
         "Sweetsop"
-      ]
+      ],
+      "theme": "autumn"
     },
     {
       "id": "festival",
@@ -378,9 +382,9 @@
       "difficulty": 3,
       "duration": 170,
       "stars": [
-        120,
-        230,
-        360
+        150,
+        300,
+        470
       ],
       "events": [
         "rain",
@@ -450,6 +454,90 @@
         "Carrot",
         "Potato",
         "Tomato",
+        "Corn",
+        "SuspeciousLemon",
+        "Aubergine",
+        "DarkCarrot",
+        "GrapeTomato",
+        "Pepper",
+        "Sweetsop"
+      ],
+      "theme": "night"
+    },
+    {
+      "id": "pomar-noturno",
+      "name": "Pomar Noturno",
+      "theme": "night",
+      "boss": {
+        "at": 0.55,
+        "qty": 4,
+        "time": 55,
+        "rewardMult": 4
+      },
+      "difficulty": 3,
+      "duration": 165,
+      "stars": [
+        170,
+        330,
+        500
+      ],
+      "events": [
+        "rain",
+        "rush"
+      ],
+      "plots": [
+        {
+          "x": 300,
+          "y": 230
+        },
+        {
+          "x": 430,
+          "y": 230
+        },
+        {
+          "x": 560,
+          "y": 230
+        },
+        {
+          "x": 690,
+          "y": 230
+        },
+        {
+          "x": 360,
+          "y": 400
+        },
+        {
+          "x": 490,
+          "y": 400
+        },
+        {
+          "x": 620,
+          "y": 400
+        }
+      ],
+      "stations": [
+        {
+          "type": "tool",
+          "x": 92,
+          "y": 250
+        },
+        {
+          "type": "seed",
+          "x": 92,
+          "y": 420
+        },
+        {
+          "type": "water",
+          "x": 868,
+          "y": 320
+        },
+        {
+          "type": "sales",
+          "x": 480,
+          "y": 548
+        }
+      ],
+      "plantPool": [
         "Corn",
         "SuspeciousLemon",
         "Aubergine",

--- a/web/game.js
+++ b/web/game.js
@@ -371,6 +371,7 @@ function render() {
   drawPlayers();
   drawParticles();
   drawFloaters();
+  drawThemeOverlay();
   ctx.restore();
   drawWeatherTint();
   updateClientFX();
@@ -382,13 +383,27 @@ function render() {
   for (const p of game.players) if (p.seedMenu.open) drawSeedMenu(p);
 }
 
+// Per-level visual themes (cosmetic). "default" matches the original look so
+// quick play / the e2e harness render identically.
+const THEMES = {
+  default: { ground: "#6ab04c", overlay: null },
+  spring: { ground: "#6ab04c", overlay: "rgba(150,230,160,0.05)" },
+  summer: { ground: "#74b84a", overlay: "rgba(255,235,150,0.06)" },
+  autumn: { ground: "#9a8b3c", overlay: "rgba(200,120,40,0.12)" },
+  night: { ground: "#3f4d6e", overlay: "rgba(24,34,86,0.30)" },
+};
+function theme() { return THEMES[game.theme] || THEMES.default; }
 function drawBackground() {
-  ctx.fillStyle = "#6ab04c";
+  ctx.fillStyle = theme().ground;
   ctx.fillRect(0, 0, WORLD.w, WORLD.h);
   if (ASSETS.atlas.tiles.grass) {
     for (let y = 0; y < WORLD.h; y += TILE_PX) for (let x = 0; x < WORLD.w; x += TILE_PX) drawTile("grass", 1, 3, x, y, TILE_PX, TILE_PX);
   }
   drawFence();
+}
+function drawThemeOverlay() {
+  const ov = theme().overlay; if (!ov) return;
+  ctx.fillStyle = ov; ctx.fillRect(0, 0, WORLD.w, WORLD.h);
 }
 function drawFence() {
   if (!ASSETS.atlas.tiles.fence) return;

--- a/web/net.js
+++ b/web/net.js
@@ -95,7 +95,7 @@ export const Net = {
     const pp = prev && prev.players, qp = prev && prev.plots, qo = prev && prev.orders;
     return {
       time: s.time, score: s.score, combo: s.combo, playerCount: s.playerCount,
-      over: s.over, result: s.result, levelName: s.levelName, weather: s.weather,
+      over: s.over, result: s.result, levelName: s.levelName, theme: s.theme, weather: s.weather,
       plantPool: s.plantPool ? s.plantPool.map(plant).filter(Boolean) : null,
       particles: [], floaters: [], shake: 0, anyMoving: false,
       stations: s.stations || stations(),

--- a/web/sim.js
+++ b/web/sim.js
@@ -115,7 +115,7 @@ export function createState({ playerCount = 1, difficulty = 1, seed = null, leve
   return {
     _rng: seed != null ? makeRng(seed) : null,
     mult: DIFFICULTY_MULT[difficulty - 1], difficulty, playerCount, mods: M,
-    levelId: L.id, levelName: L.name, duration, starsBase: L.stars.slice(),
+    levelId: L.id, levelName: L.name, theme: L.theme || "default", duration, starsBase: L.stars.slice(),
     plantPool: pool.length ? pool : PLANTS.slice(),
     score: 0, paused: false, over: false, result: null,
     eventTypes: (L.events || []).filter((t) => EVENTS.defs[t]),


### PR DESCRIPTION
## PR C — Fases temáticas

Terceiro pacote do backlog: clima visual por fase + uma fase nova.

### Temas
- Campo `theme` por fase (**spring / summer / autumn / night**): cor de chão + overlay de mood sobre o mundo. `"default"` reproduz o visual original → **quick play e e2e idênticos**.
- `theme` no estado + snapshot → **online mostra o mesmo clima**.

### Conteúdo / fluidez
- **Fase nova: Pomar Noturno** (noite, 7 canteiros, diff 3, chuva+rush, chefe).
- **Mercado**: estações normalizadas — os cantos extremos travavam o bot **e** a jogabilidade (caminhada excessiva). Continua difícil por pressão (diff3+seca+chefe), não por andar.
- **Estufa**: só `rush` (seca+chefe juntos craterava o nível).

### Metas
Curva **monotônica à mão** (Quintal→Pomar). O bot planta 1 cultivo por vez e **subrepresenta fases de muitos canteiros** (8 canteiros = humano planta em paralelo), então o teto dele não serve pra ★2/★3 nessas; usei como sanidade e verifiquei que **★1 é alcançável pelo bot em toda fase** (piso de "campanha completável").

### Testes
- e2e default **idêntico** (90/84) · teste de rede ok · tema noturno + chuva renderiza sem erro (screenshot no PR).

Último: **PR D — upgrades novos + glifos de controle**.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_