### PR TITLE
Novos upgrades + glifos de controle (PR D)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -28,11 +28,15 @@ Client-side (render/áudio); sim só ganhou rótulos de cue (gameplay-neutro).
 - ✅ Mercado: estações normalizadas (cantos extremos quebravam bot e fluidez); Estufa: só rush (seca+chefe junto craterava).
 - ✅ Metas em **curva monotônica à mão** (bot subrepresenta fases de muitos canteiros; ★1 verificado alcançável pelo bot como piso de "campanha completável").
 
-## PR D — Novos upgrades + UX ⬜
-- ⬜ Upgrades novos com hook no sim: Regador Duplo (rega canteiro vizinho),
-  Viveiro (começa com canteiros tratados), Comerciante (combo dura mais).
-- ⬜ Glifos de controle nas dicas de interação.
-- ⬜ Recalibrar metas das fases afetadas.
+## PR D — Novos upgrades + UX ✅
+- ✅ Upgrades novos com hook no sim: **Regador Duplo** (rega o vizinho mais carente),
+  **Viveiro** (começa com N canteiros tratados), **Comerciante** (combo dura +2.5s/nível).
+- ✅ Glifos de controle nas dicas de interação (E · / · ↵ · Ⓐ conforme o dispositivo).
+- ✅ Sem recalibração: upgrades só valem no offline com o item comprado (headless = identidade).
+
+---
+**Backlog desta leva concluído.** Próximas frentes (fora do escopo): deploy do
+servidor, acessibilidade, multiplayer local no celular, host kick/migration.
 
 ## Princípios
 - Nível **default** sem features opt-in → harness/e2e por-PR inalterado (90/84).

--- a/web/game.js
+++ b/web/game.js
@@ -632,23 +632,34 @@ function heldLabel(p) {
   }
 }
 
+function interactGlyph(p) {
+  const d = p.device;
+  if (d) {
+    if (d.type === "gamepad") return "Ⓐ";
+    const k = d.keymap && d.keymap.interact && d.keymap.interact[0];
+    if (k === "slash") return "/";
+    if (k === "enter") return "↵";
+  }
+  return "E";
+}
 function drawInteractHint(p) {
   if (p.seedMenu.open) return;
   const station = Sim.nearestStation(game, p);
   const plot = !station ? Sim.nearestPlot(game, p) : null;
+  const g = interactGlyph(p);
   let hint = null;
   if (station) {
-    if (station.type === "tool") hint = "E: pegar enxada";
-    if (station.type === "water") hint = "E: pegar água";
-    if (station.type === "seed") hint = p.holding !== HOLD.PLANT ? "E: escolher semente" : null;
-    if (station.type === "sales") hint = p.holding === HOLD.PLANT ? "E: entregar" : null;
+    if (station.type === "tool") hint = `${g}: pegar enxada`;
+    if (station.type === "water") hint = `${g}: pegar água`;
+    if (station.type === "seed") hint = p.holding !== HOLD.PLANT ? `${g}: escolher semente` : null;
+    if (station.type === "sales") hint = p.holding === HOLD.PLANT ? `${g}: entregar` : null;
   } else if (plot) {
     const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
-    if (plot.stage === STAGE.VIRGIN && p.holding === HOLD.TOOL) hint = "E: preparar terra";
-    else if (plot.stage === STAGE.TREATED && p.holding === HOLD.SEED) hint = "E: plantar";
-    else if (growing && p.holding === HOLD.WATER) hint = "E: regar";
-    else if (plot.stage === STAGE.READY && p.holding === HOLD.NOTHING) hint = "E: colher";
-    else if (plot.stage === STAGE.DIED && p.holding === HOLD.TOOL) hint = "E: limpar terra";
+    if (plot.stage === STAGE.VIRGIN && p.holding === HOLD.TOOL) hint = `${g}: preparar terra`;
+    else if (plot.stage === STAGE.TREATED && p.holding === HOLD.SEED) hint = `${g}: plantar`;
+    else if (growing && p.holding === HOLD.WATER) hint = `${g}: regar`;
+    else if (plot.stage === STAGE.READY && p.holding === HOLD.NOTHING) hint = `${g}: colher`;
+    else if (plot.stage === STAGE.DIED && p.holding === HOLD.TOOL) hint = `${g}: limpar terra`;
   }
   if (!hint) return;
   ctx.font = "bold 16px Trebuchet MS, sans-serif"; ctx.textAlign = "center";

--- a/web/shop.js
+++ b/web/shop.js
@@ -14,6 +14,9 @@ export const UPGRADES = [
   { id: "fertilizer", name: "Adubo", icon: "🌿", desc: "Plantas murcham ~12% mais devagar", max: 3, cost: [150, 320, 520] },
   { id: "greenhouse", name: "Estufa Rápida", icon: "🌱", desc: "Crescimento ~8% mais rápido", max: 3, cost: [180, 360, 600] },
   { id: "clock", name: "Relógio Extra", icon: "⏱️", desc: "+8s de rodada por nível", max: 2, cost: [220, 420] },
+  { id: "splash", name: "Regador Duplo", icon: "💦", desc: "Regar molha também um canteiro vizinho", max: 1, cost: [420] },
+  { id: "nursery", name: "Viveiro", icon: "🪴", desc: "Começa com canteiros já preparados", max: 2, cost: [200, 400] },
+  { id: "merchant", name: "Comerciante", icon: "🤝", desc: "Combo dura +2.5s por nível", max: 2, cost: [240, 440] },
 ];
 
 export const Shop = {
@@ -46,6 +49,9 @@ export const Shop = {
       decayMult: 1 - 0.12 * (L.fertilizer || 0),
       growthMult: 1 - 0.08 * (L.greenhouse || 0),
       bonusTime: 8 * (L.clock || 0),
+      waterSplash: (L.splash || 0) > 0,
+      startTreated: L.nursery || 0,
+      comboBonus: 2.5 * (L.merchant || 0),
     };
   },
 };

--- a/web/sim.js
+++ b/web/sim.js
@@ -99,6 +99,7 @@ export function createState({ playerCount = 1, difficulty = 1, seed = null, leve
   playerCount = Math.max(1, Math.min(4, playerCount));
   difficulty = Math.max(1, Math.min(4, L.difficulty != null ? L.difficulty : difficulty));
   const plots = L.plots.map((p) => ({ x: p.x, y: p.y, stage: STAGE.VIRGIN, plant: null, progress: 0, life: 1, wilt: 0 }));
+  for (let i = 0; i < Math.min(M.startTreated || 0, plots.length); i++) { plots[i].stage = STAGE.TREATED; plots[i].life = 1; } // Viveiro
   const stations = L.stations.map((s) => ({ type: s.type, x: s.x, y: s.y, label: (STATION_META[s.type] || {}).label || s.type, icon: (STATION_META[s.type] || {}).icon }));
   const pool = L.plantPool && L.plantPool.length ? PLANTS.filter((p) => L.plantPool.includes(p.name)) : PLANTS.slice();
   const players = [];
@@ -239,7 +240,7 @@ function deliverPlant(s, p) {
 function completeOrder(s, o) {
   const base = ORDER.baseReward * o.plant.rarity * o.qty;
   const tip = Math.round(base * 0.5 * (o.timeLeft / o.maxTime));
-  s.combo++; s.comboTimer = ORDER.comboWindow;
+  s.combo++; s.comboTimer = ORDER.comboWindow + (s.mods.comboBonus || 0);
   const mult = 1 + 0.1 * Math.min(s.combo - 1, 9);
   const total = Math.round((base + tip) * mult * rushMult(s) * (o.boss ? (o.rewardMult || 1) : 1));
   s.score += total; s.stats.delivered++;
@@ -286,7 +287,16 @@ function interactPlot(s, p, plot) {
   const growing = plot.stage >= STAGE.SMALL && plot.stage < STAGE.READY;
   if (p.holding === HOLD.WATER && growing) {
     plot.life = 1; plot.wilt = 0; p.holding = HOLD.NOTHING; ev(s, "watering");
-    spawnParticles(s, plot.x, plot.y - 10, { n: 10, color: "#7ec8ff", speed: 110 }); return;
+    spawnParticles(s, plot.x, plot.y - 10, { n: 10, color: "#7ec8ff", speed: 110 });
+    if (s.mods.waterSplash) { // Regador Duplo: rega o vizinho crescente mais carente
+      let best = null, bd = Infinity;
+      for (const o of s.plots) {
+        if (o === plot || !(o.stage >= STAGE.SMALL && o.stage < STAGE.READY) || o.life >= 0.99) continue;
+        const dd = dist(plot.x, plot.y, o.x, o.y); if (dd < bd) { bd = dd; best = o; }
+      }
+      if (best) { best.life = 1; best.wilt = 0; spawnParticles(s, best.x, best.y - 10, { n: 8, color: "#7ec8ff", speed: 90 }); }
+    }
+    return;
   }
   if (p.holding === HOLD.NOTHING && plot.stage === STAGE.READY) {
     p.holding = HOLD.PLANT; p.heldPlant = plot.plant;


### PR DESCRIPTION
## PR D — Novos upgrades + glifos de controle (fecha o backlog)

Último pacote da leva.

### Upgrades novos (com hook no sim)
- 💦 **Regador Duplo** — regar molha também o canteiro crescente mais carente.
- 🪴 **Viveiro** — começa a rodada com N canteiros já preparados (×2).
- 🤝 **Comerciante** — janela de combo +2.5s por nível (×2).

Aplicados via `createState` (Viveiro), `interactPlot` (Regador) e `completeOrder` (Comerciante). **Sem recalibração**: só valem no offline com o item comprado; headless = identidade → e2e intacto.

### UX
- Dicas de interação mostram o **glifo do dispositivo** do jogador (`E` · `/` · `↵` · `Ⓐ`) em vez de "E" fixo — útil pra P2/gamepad.

### Testes
- e2e default **idêntico** (90/84) · teste de rede ok · os 3 upgrades aplicam no estado (Viveiro→2 canteiros tratados, comboBonus 2.5, waterSplash true).

### Backlog
Com este PR, **a leva planejada em `docs/BACKLOG.md` está completa** (A lobby · B áudio/FX · C fases temáticas · D upgrades). Fora do escopo (próximas): deploy do servidor, acessibilidade, multiplayer local no celular.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_