### PR TITLE
UI mobile: cara de app nativo (PWA + safe-area + mobile-first)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,15 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 <title>Overgarden — Web</title>
+<meta name="description" content="Overgarden — cuide da sua fazenda num loop frenético: plante, regue, colha e entregue." />
+<meta name="theme-color" content="#1a2417" />
+<!-- Installable / standalone for a native-app feel on mobile -->
+<link rel="manifest" href="manifest.webmanifest" />
+<meta name="mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="apple-mobile-web-app-title" content="Overgarden" />
+<link rel="apple-touch-icon" href="assets/img/ui_logo.png" />
 <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -20,17 +29,21 @@
       </p>
       <div class="choices">
         <span>Jogadores:</span>
-        <button class="count-btn selected" data-count="1">1</button>
-        <button class="count-btn" data-count="2">2</button>
-        <button class="count-btn" data-count="3">3</button>
-        <button class="count-btn" data-count="4">4</button>
+        <div class="seg">
+          <button class="count-btn selected" data-count="1">1</button>
+          <button class="count-btn" data-count="2">2</button>
+          <button class="count-btn" data-count="3">3</button>
+          <button class="count-btn" data-count="4">4</button>
+        </div>
       </div>
       <div class="choices">
         <span>Dificuldade:</span>
-        <button class="diff-btn selected" data-diff="1">Fácil</button>
-        <button class="diff-btn" data-diff="2">Médio</button>
-        <button class="diff-btn" data-diff="3">Difícil</button>
-        <button class="diff-btn" data-diff="4">Insano</button>
+        <div class="seg">
+          <button class="diff-btn selected" data-diff="1">Fácil</button>
+          <button class="diff-btn" data-diff="2">Médio</button>
+          <button class="diff-btn" data-diff="3">Difícil</button>
+          <button class="diff-btn" data-diff="4">Insano</button>
+        </div>
       </div>
       <button id="campaign-btn" class="big-btn" disabled>🗺️ Campanha</button>
       <button id="start-btn" class="big-btn secondary" disabled>Jogo rápido</button>
@@ -38,16 +51,18 @@
       <button id="shop-btn" class="big-btn secondary">🛒 Loja</button>
       <button id="stats-btn" class="big-btn secondary">📊 Estatísticas</button>
       <div class="controls">
-        <strong>P1:</strong> WASD mover · SHIFT correr · E interagir · Q largar · P pausar
-        <br />
-        <strong>P2:</strong> setas · Shift-direito correr · <kbd>/</kbd> interagir · <kbd>.</kbd> largar
-        <br />
-        <strong>P3–P4:</strong> gamepad (stick mover · A interagir · B largar · RB correr)
-        <br />
-        <span class="mobile-hint">No celular (1 jogador): use os botões na tela (gire para paisagem para mais espaço).</span>
-        <br />
-        <label class="mute-toggle"><input type="checkbox" id="mute-box" /> Silenciar áudio</label>
-        <label class="vol-toggle">🔊 <input type="range" id="vol-range" min="0" max="100" value="80" /></label>
+        <div class="kbd-hints">
+          <strong>P1:</strong> WASD mover · SHIFT correr · E interagir · Q largar · P pausar
+          <br />
+          <strong>P2:</strong> setas · Shift-direito correr · <kbd>/</kbd> interagir · <kbd>.</kbd> largar
+          <br />
+          <strong>P3–P4:</strong> gamepad (stick mover · A interagir · B largar · RB correr)
+        </div>
+        <span class="mobile-hint">Use os controles na tela. Gire para paisagem para mais espaço.</span>
+        <div class="audio-row">
+          <label class="mute-toggle"><input type="checkbox" id="mute-box" /> Silenciar</label>
+          <label class="vol-toggle">🔊 <input type="range" id="vol-range" min="0" max="100" value="80" /></label>
+        </div>
       </div>
     </div>
 

--- a/web/manifest.webmanifest
+++ b/web/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Overgarden",
+  "short_name": "Overgarden",
+  "description": "Cuide da sua fazenda num loop frenético: plante, regue, colha e entregue.",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#1a2417",
+  "theme_color": "#1a2417",
+  "icons": [
+    { "src": "assets/img/ui_logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
+    { "src": "assets/img/ui_logo.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/web/style.css
+++ b/web/style.css
@@ -60,7 +60,7 @@ canvas#game {
 
 .overlay h1 {
   font-size: clamp(34px, 7vw, 54px);
-  letter-spacing: 6px;
+  letter-spacing: 2px;
   color: #f7d774;
   text-shadow: 0 3px 0 #7a5b18;
 }
@@ -91,6 +91,7 @@ canvas#game {
 }
 
 .choices span { font-weight: bold; margin-right: 4px; min-width: 92px; text-align: right; }
+.seg { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
 
 .diff-btn, .count-btn {
   background: #3c5230;
@@ -216,7 +217,10 @@ canvas#game {
 }
 
 .big-btn:hover { background: #ffe48a; transform: translateY(-2px); }
+.big-btn:active { transform: translateY(1px) scale(0.99); }
 .big-btn:disabled { opacity: 0.55; cursor: default; transform: none; }
+button { -webkit-tap-highlight-color: transparent; }
+.diff-btn:active, .count-btn:active, .ocount-btn:active, .copy-btn:active, .shop-card .sc-buy:active { transform: translateY(1px); }
 .big-btn.secondary {
   background: #3c5230;
   color: #e7e0cd;
@@ -233,13 +237,14 @@ canvas#game {
   line-height: 1.6;
 }
 
-.mobile-hint { color: #f7d774; }
+.kbd-hints { line-height: 1.6; }
+.mobile-hint { display: none; color: #f7d774; }
+.audio-row { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; justify-content: center; margin-top: 10px; }
 
 .mute-toggle {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-top: 6px;
   cursor: pointer;
 }
 
@@ -336,9 +341,60 @@ canvas#game {
 @media (pointer: coarse) {
   #touch-controls.active { display: flex; }
   .footnote { display: none; }
+  /* Keyboard/gamepad hints are noise on touch; show the on-screen hint instead. */
+  .kbd-hints { display: none; }
+  .mobile-hint { display: block; }
 }
 
 /* Hide footnote on short screens to maximise play area. */
 @media (max-height: 520px) {
   .footnote { display: none; }
+}
+
+/* ------------------------------------------------ Mobile-first / native feel.
+   Phone-width menus: anchor to the top (no big vertical gaps), respect the
+   notch/home-indicator safe areas, full-width stacked CTAs, and segmented
+   pickers instead of a web-form row. */
+@media (max-width: 560px) {
+  .overlay {
+    justify-content: flex-start;
+    gap: 12px;
+    padding: calc(env(safe-area-inset-top) + 22px) max(16px, env(safe-area-inset-right))
+             calc(env(safe-area-inset-bottom) + 16px) max(16px, env(safe-area-inset-left));
+  }
+  .overlay h1 { font-size: clamp(30px, 9vw, 44px); }
+  #logo { width: clamp(110px, 30vw, 190px); margin-top: 2px; }
+  .tagline { margin-top: -4px; }
+
+  /* One consistent, thumb-sized CTA width down the screen. */
+  .big-btn, .big-btn.secondary {
+    width: 100%;
+    max-width: 380px;
+    padding: 15px 20px;
+    font-size: 17px;
+  }
+
+  /* Player/difficulty as a full-width segmented control with the label above. */
+  .choices {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    max-width: 380px;
+    gap: 6px;
+    margin: 0;
+  }
+  .choices span {
+    min-width: 0;
+    text-align: left;
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: #9bb583;
+  }
+  .seg { flex-wrap: nowrap; width: 100%; gap: 6px; }
+  .seg > button { flex: 1; min-width: 0; padding: 12px 4px; }
+
+  .controls { width: 100%; max-width: 380px; margin-top: 4px; }
+  #level-grid, #shop-grid, #stats-grid { width: 100%; max-width: 420px; }
+  #level-grid { grid-template-columns: repeat(2, 1fr); }
 }


### PR DESCRIPTION
## UI mobile — cara de app nativo

Revisão da UI com foco em **parecer um app nativo no celular** (estava com cara de site/formulário).

### O que mudou
- **PWA instalável / standalone**: `manifest.webmanifest` + metas apple/`theme-color` + `apple-touch-icon` → "Adicionar à tela inicial" abre **em tela cheia, sem barra do navegador**.
- **Safe-area**: overlays respeitam notch/home-indicator via `env(safe-area-inset-*)` — conteúdo não fica mais embaixo da status bar.
- **Layout mobile-first**: telas **ancoradas no topo** (acabaram os vazios verticais gigantes); menu vira pilha de **CTAs full-width** de tamanho consistente, com feedback de toque (`:active`, sem tap-highlight cinza).
- **Segmented control**: Jogadores/Dificuldade viram seletor full-width com rótulo acima (em vez de linha de formulário).
- **Menos ruído no toque**: dicas de teclado/gamepad (P1 WASD…/P2 setas…) **escondidas em `pointer: coarse`**; dica curta na tela no lugar.
- **Grades**: Campanha em **2 colunas** no celular; loja/stats ocupam a largura.
- **Títulos**: removido o `letter-spacing` largo datado ("C a m p a n h a").
- **Desktop preservado** (segmented inline, layout centralizado).

### Antes → depois
Screenshots no chat (início, campanha, loja em iPhone + desktop).

### Limite honesto
O **logo** continua o mesmo (knot abstrato re-paletizado); um wordmark/ícone dedicado deixaria ainda mais "app", mas isso é arte. O HUD in-game (canvas) não foi tocado além dos controles de toque já existentes.

### Testes
- Mobile (iPhone) e desktop renderizam **sem erro de página**; `manifest.webmanifest` responde 200; e2e default 75/75.

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_