### PR TITLE
UI: menu inicial mais limpo (hierarquia + mobile)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -27,7 +27,7 @@
         Você achou uma fazenda no meio do nada. Mantenha-a viva num loop
         infinito: prepare a terra, plante, regue, colha e venda para somar pontos.
       </p>
-      <div class="choices">
+      <div class="choices choice-count">
         <span>Jogadores:</span>
         <div class="seg">
           <button class="count-btn selected" data-count="1">1</button>
@@ -36,7 +36,7 @@
           <button class="count-btn" data-count="4">4</button>
         </div>
       </div>
-      <div class="choices">
+      <div class="choices choice-diff">
         <span>Dificuldade:</span>
         <div class="seg">
           <button class="diff-btn selected" data-diff="1">Fácil</button>
@@ -45,11 +45,16 @@
           <button class="diff-btn" data-diff="4">Insano</button>
         </div>
       </div>
-      <button id="campaign-btn" class="big-btn" disabled>🗺️ Campanha</button>
-      <button id="start-btn" class="big-btn secondary" disabled>Jogo rápido</button>
-      <button id="online-btn" class="big-btn secondary">🌐 Jogar online</button>
-      <button id="shop-btn" class="big-btn secondary">🛒 Loja</button>
-      <button id="stats-btn" class="big-btn secondary">📊 Estatísticas</button>
+      <div class="menu-play">
+        <button id="campaign-btn" class="big-btn" disabled>🗺️ Campanha</button>
+        <button id="start-btn" class="big-btn secondary" disabled>Jogo rápido</button>
+      </div>
+      <div class="menu-utils">
+        <!-- Online fica fora do menu até o servidor ser deployado (.util-online em style.css). -->
+        <button id="online-btn" class="big-btn secondary util-online">🌐 Online</button>
+        <button id="shop-btn" class="big-btn secondary">🛒 Loja</button>
+        <button id="stats-btn" class="big-btn secondary">📊 Estatísticas</button>
+      </div>
       <div class="controls">
         <div class="kbd-hints">
           <strong>P1:</strong> WASD mover · SHIFT correr · E interagir · Q largar · P pausar

--- a/web/style.css
+++ b/web/style.css
@@ -228,6 +228,14 @@ button { -webkit-tap-highlight-color: transparent; }
 }
 .big-btn.secondary:hover { background: #4d6a3c; }
 
+/* Menu grouping: a primary play stack + an aggregated, lower-emphasis row of
+   utilities (loja/stats) so the screen isn't a wall of equal buttons. */
+.menu-play { display: flex; flex-direction: column; align-items: center; gap: clamp(8px, 2vh, 14px); width: 100%; }
+.menu-utils { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; }
+.menu-utils .big-btn { font-size: clamp(13px, 3.2vw, 15px); padding: 9px 18px; }
+/* Online stays in the markup but hidden until the multiplayer server is deployed. */
+.util-online { display: none; }
+
 .controls {
   margin-top: 8px;
   font-size: clamp(11px, 3vw, 14px);
@@ -396,4 +404,19 @@ button { -webkit-tap-highlight-color: transparent; }
   .controls { width: 100%; max-width: 380px; margin-top: 4px; }
   #level-grid, #shop-grid, #stats-grid { width: 100%; max-width: 420px; }
   #level-grid { grid-template-columns: repeat(2, 1fr); }
+  .menu-play, .menu-utils { width: 100%; max-width: 380px; }
+
+  /* Start screen on phones: declutter + thumb-first hierarchy.
+     - Single-player only on a phone → hide the players picker.
+     - Drop the long blurb.
+     - Push the action cluster to the bottom (thumb zone); the primary CTA
+       (Campanha) lands lowest via column-reverse. */
+  #start-screen .desc, #start-screen .choice-count { display: none; }
+  #start-screen #logo { order: 1; margin-top: auto; }
+  #start-screen .tagline { order: 2; }
+  #start-screen .menu-utils { order: 4; margin-top: auto; }
+  #start-screen .choice-diff { order: 5; }
+  #start-screen .menu-play { order: 6; flex-direction: column-reverse; align-items: stretch; }
+  #start-screen .controls { order: 7; }
+  .menu-utils .big-btn { flex: 1; width: auto; max-width: none; }
 }


### PR DESCRIPTION
## Menu inicial mais limpo e amigável

Atende ao feedback: a tela estava poluída, sem hierarquia, com botões demais e opções que não fazem sentido no contexto.

### Mudanças
- **Mobile — seletor de Jogadores escondido**: só dá pra jogar 1 pessoa por celular (o default já é 1). Mantido no desktop, onde o co-op local é real.
- **Online fora do menu** enquanto o servidor não está deployado. O markup e a lógica continuam lá; só a entrada fica oculta (`.util-online`) — reativar é uma linha.
- **Agregação**: de 5 botões empilhados para **Campanha** (primário) + **Jogo rápido** + uma linha compacta **Loja · Estatísticas**.
- **Hierarquia thumb-first (mobile)**: hero centralizado em cima, cluster de ações ancorado embaixo, com a **ação principal (Campanha) por último** — pertinho do polegar.
- **Menos ruído**: parágrafo longo escondido no mobile.
- **Desktop preservado** (mantém Jogadores; utilitários viram linha compacta em vez de pilha).

### Antes → depois
Screenshots no chat (mobile e desktop).

### Testes
- Mobile (iPhone) e desktop renderizam sem erro; **Jogo rápido inicia com 1 jogador** mesmo com o seletor oculto (`playerCount=1`).

https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RirE2ctCLe4m4ZGVVnXycd)_